### PR TITLE
Fix source node ID generation when transforming via bundler

### DIFF
--- a/.changeset/fifty-kids-kneel.md
+++ b/.changeset/fifty-kids-kneel.md
@@ -1,0 +1,14 @@
+---
+"@toolcog/compiler": patch
+"@toolcog/runtime": patch
+"@toolcog/core": patch
+---
+
+Fix source node ID generation when transforming via bundler
+
+`@id` doc tags can now be used to override automatic source node ID generation.
+`@noid` doc tags can also now be used to prevent enclosing named blocks from
+being included in generated source node IDs.
+
+The parameter type of the `defineIndex` intrinsic now properly reflects the
+fact that it can be called with an array of pre-generated idioms.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,7 +12,7 @@ export default pluginTs.config(
       "jsdoc/check-line-alignment": "error",
       "jsdoc/check-tag-names": [
         "error",
-        { definedTags: ["instructions", "idiom"] },
+        { definedTags: ["id", "idiom", "instructions", "noid"] },
       ],
       "jsdoc/no-bad-blocks": "error",
       "jsdoc/require-jsdoc": "off",

--- a/packages/framework/compiler/src/intrinsics/define-idiom.ts
+++ b/packages/framework/compiler/src/intrinsics/define-idiom.ts
@@ -8,10 +8,11 @@ import { getNodeTypeId } from "../node-id.ts";
 
 const defineIdiomExpression = (
   ts: typeof import("typescript"),
+  host: ts.ModuleResolutionHost,
+  program: ts.Program,
   factory: ts.NodeFactory,
   checker: ts.TypeChecker,
   addDiagnostic: (diagnostic: ts.Diagnostic) => void,
-  getCommonSourceDirectory: (() => string) | undefined,
   moduleDef: ModuleDef,
   idiomType: ts.Type,
   idiomResolverExpression: ts.Expression | undefined,
@@ -34,7 +35,8 @@ const defineIdiomExpression = (
     getNodeTypeId(ts, valueExpression, valueType, {
       package: true,
       module: true,
-      getCommonSourceDirectory,
+      host,
+      program,
     }) ?? "";
 
   if (

--- a/packages/framework/compiler/src/intrinsics/define-idioms.ts
+++ b/packages/framework/compiler/src/intrinsics/define-idioms.ts
@@ -6,10 +6,11 @@ import { defineIdiomExpression } from "./define-idiom.ts";
 
 const defineIdiomsExpression = (
   ts: typeof import("typescript"),
+  host: ts.ModuleResolutionHost,
+  program: ts.Program,
   factory: ts.NodeFactory,
   checker: ts.TypeChecker,
   addDiagnostic: (diagnostic: ts.Diagnostic) => void,
-  getCommonSourceDirectory: (() => string) | undefined,
   moduleDef: ModuleDef,
   idiomType: ts.Type,
   idiomsType: ts.Type,
@@ -52,10 +53,11 @@ const defineIdiomsExpression = (
       idiomExpressions.push(
         defineIdiomExpression(
           ts,
+          host,
+          program,
           factory,
           checker,
           addDiagnostic,
-          getCommonSourceDirectory,
           moduleDef,
           idiomType,
           idiomResolverExpression,
@@ -93,10 +95,11 @@ const defineIdiomsExpression = (
     idiomExpressions.push(
       defineIdiomExpression(
         ts,
+        host,
+        program,
         factory,
         checker,
         addDiagnostic,
-        getCommonSourceDirectory,
         moduleDef,
         idiomType,
         idiomResolverExpression,

--- a/packages/framework/compiler/src/intrinsics/define-index.ts
+++ b/packages/framework/compiler/src/intrinsics/define-index.ts
@@ -5,10 +5,11 @@ import { defineIdiomsExpression } from "./define-idioms.ts";
 
 const defineIndexExpression = (
   ts: typeof import("typescript"),
+  host: ts.ModuleResolutionHost,
+  program: ts.Program,
   factory: ts.NodeFactory,
   checker: ts.TypeChecker,
   addDiagnostic: (diagnostic: ts.Diagnostic) => void,
-  getCommonSourceDirectory: (() => string) | undefined,
   moduleDef: ModuleDef,
   idiomType: ts.Type,
   idiomsType: ts.Type,
@@ -28,7 +29,8 @@ const defineIndexExpression = (
     getNodeId(ts, callExpression, {
       package: true,
       module: true,
-      getCommonSourceDirectory,
+      host,
+      program,
     }) ?? "";
 
   if (
@@ -278,10 +280,11 @@ const defineIndexExpression = (
 
   const idiomsArgument = defineIdiomsExpression(
     ts,
+    host,
+    program,
     factory,
     checker,
     addDiagnostic,
-    getCommonSourceDirectory,
     moduleDef,
     idiomType,
     idiomsType,

--- a/packages/framework/compiler/src/intrinsics/define-prompt.ts
+++ b/packages/framework/compiler/src/intrinsics/define-prompt.ts
@@ -9,10 +9,11 @@ import { signatureToSchema } from "../schema.ts";
 
 const definePromptExpression = (
   ts: typeof import("typescript"),
+  host: ts.ModuleResolutionHost,
+  program: ts.Program,
   factory: ts.NodeFactory,
   checker: ts.TypeChecker,
   addDiagnostic: (diagnostic: ts.Diagnostic) => void,
-  getCommonSourceDirectory: (() => string) | undefined,
   moduleDef: ModuleDef,
   generatorExpression: ts.Expression,
   contextToolsExpression: ts.Expression | undefined,
@@ -36,7 +37,8 @@ const definePromptExpression = (
     getNodeId(ts, callExpression, {
       package: true,
       module: true,
-      getCommonSourceDirectory,
+      host,
+      program,
     }) ?? "";
 
   if (

--- a/packages/framework/compiler/src/intrinsics/define-tool.ts
+++ b/packages/framework/compiler/src/intrinsics/define-tool.ts
@@ -11,10 +11,11 @@ import { signatureToSchema } from "../schema.ts";
 
 const defineToolExpression = (
   ts: typeof import("typescript"),
+  host: ts.ModuleResolutionHost,
+  program: ts.Program,
   factory: ts.NodeFactory,
   checker: ts.TypeChecker,
   addDiagnostic: (diagnostic: ts.Diagnostic) => void,
-  getCommonSourceDirectory: (() => string) | undefined,
   moduleDef: ModuleDef,
   toolType: ts.Type,
   funcExpression: ts.Expression,
@@ -38,7 +39,8 @@ const defineToolExpression = (
     getNodeTypeId(ts, funcExpression, funcType, {
       package: true,
       module: true,
-      getCommonSourceDirectory,
+      host,
+      program,
     }) ?? "";
 
   if (

--- a/packages/framework/compiler/src/intrinsics/define-tools.ts
+++ b/packages/framework/compiler/src/intrinsics/define-tools.ts
@@ -6,10 +6,11 @@ import { defineToolExpression } from "./define-tool.ts";
 
 const defineToolsExpression = (
   ts: typeof import("typescript"),
+  host: ts.ModuleResolutionHost,
+  program: ts.Program,
   factory: ts.NodeFactory,
   checker: ts.TypeChecker,
   addDiagnostic: (diagnostic: ts.Diagnostic) => void,
-  getCommonSourceDirectory: (() => string) | undefined,
   moduleDef: ModuleDef,
   toolType: ts.Type,
   toolsType: ts.Type,
@@ -50,10 +51,11 @@ const defineToolsExpression = (
       toolExpressions.push(
         defineToolExpression(
           ts,
+          host,
+          program,
           factory,
           checker,
           addDiagnostic,
-          getCommonSourceDirectory,
           moduleDef,
           toolType,
           element,
@@ -89,10 +91,11 @@ const defineToolsExpression = (
     toolExpressions.push(
       defineToolExpression(
         ts,
+        host,
+        program,
         factory,
         checker,
         addDiagnostic,
-        getCommonSourceDirectory,
         moduleDef,
         toolType,
         factory.createElementAccessExpression(funcsExpression, index),

--- a/packages/framework/compiler/src/intrinsics/prompt.ts
+++ b/packages/framework/compiler/src/intrinsics/prompt.ts
@@ -9,10 +9,11 @@ import { callSiteToSchema } from "../schema.ts";
 
 const promptExpression = (
   ts: typeof import("typescript"),
+  host: ts.ModuleResolutionHost,
+  program: ts.Program,
   factory: ts.NodeFactory,
   checker: ts.TypeChecker,
   addDiagnostic: (diagnostic: ts.Diagnostic) => void,
-  getCommonSourceDirectory: (() => string) | undefined,
   moduleDef: ModuleDef,
   generatorExpression: ts.Expression,
   contextToolsExpression: ts.Expression | undefined,
@@ -41,7 +42,8 @@ const promptExpression = (
     getNodeId(ts, callExpression, {
       package: true,
       module: true,
-      getCommonSourceDirectory,
+      host,
+      program,
     }) ?? "";
 
   if (

--- a/packages/framework/compiler/src/transformer.ts
+++ b/packages/framework/compiler/src/transformer.ts
@@ -290,7 +290,8 @@ const transformToolcog = (
     const moduleId = getNodeId(ts, sourceFile, {
       package: true,
       module: true,
-      getCommonSourceDirectory: program.getCommonSourceDirectory,
+      host,
+      program,
     })!;
     const moduleDef = createModuleDef();
     manifest.modules[moduleId] = moduleDef;
@@ -307,10 +308,11 @@ const transformToolcog = (
         const valueExpression = node.arguments[0]!;
         node = defineIdiomExpression(
           ts,
+          host,
+          program,
           factory,
           checker,
           addDiagnostic,
-          program.getCommonSourceDirectory,
           moduleDef,
           intrinsicTypes.AnyIdiom,
           idiomResolverExpression,
@@ -331,10 +333,11 @@ const transformToolcog = (
         const valuesExpression = node.arguments[0]!;
         node = defineIdiomsExpression(
           ts,
+          host,
+          program,
           factory,
           checker,
           addDiagnostic,
-          program.getCommonSourceDirectory,
           moduleDef,
           intrinsicTypes.AnyIdiom,
           intrinsicTypes.AnyIdioms,
@@ -357,10 +360,11 @@ const transformToolcog = (
         needsIdiomResolver = true;
         node = defineIndexExpression(
           ts,
+          host,
+          program,
           factory,
           checker,
           addDiagnostic,
-          program.getCommonSourceDirectory,
           moduleDef,
           intrinsicTypes.AnyIdiom,
           intrinsicTypes.AnyIdioms,
@@ -380,10 +384,11 @@ const transformToolcog = (
         const funcExpression = node.arguments[0]!;
         node = defineToolExpression(
           ts,
+          host,
+          program,
           factory,
           checker,
           addDiagnostic,
-          program.getCommonSourceDirectory,
           moduleDef,
           intrinsicTypes.AnyTool,
           funcExpression,
@@ -402,10 +407,11 @@ const transformToolcog = (
         const funcsExpression = node.arguments[0]!;
         node = defineToolsExpression(
           ts,
+          host,
+          program,
           factory,
           checker,
           addDiagnostic,
-          program.getCommonSourceDirectory,
           moduleDef,
           intrinsicTypes.AnyTool,
           intrinsicTypes.AnyTools,
@@ -429,10 +435,11 @@ const transformToolcog = (
         needsContextTools = true;
         node = definePromptExpression(
           ts,
+          host,
+          program,
           factory,
           checker,
           addDiagnostic,
-          program.getCommonSourceDirectory,
           moduleDef,
           generatorExpression!,
           contextToolsExpression,
@@ -449,10 +456,11 @@ const transformToolcog = (
         needsContextTools = true;
         node = promptExpression(
           ts,
+          host,
+          program,
           factory,
           checker,
           addDiagnostic,
-          program.getCommonSourceDirectory,
           moduleDef,
           generatorExpression!,
           contextToolsExpression,

--- a/packages/framework/core/src/idiom.ts
+++ b/packages/framework/core/src/idiom.ts
@@ -99,7 +99,7 @@ interface Index<T extends readonly unknown[]> {
 
 const defineIndex: {
   <const T extends readonly unknown[]>(
-    values: readonly [...T],
+    values: readonly [...T] | Idioms<T>,
     config?: IndexConfig,
   ): Index<T>;
 
@@ -107,7 +107,7 @@ const defineIndex: {
   readonly brand: unique symbol;
 } = Object.assign(
   <const T extends readonly unknown[]>(
-    values: readonly [...T],
+    values: readonly [...T] | Idioms<T>,
     config?: IndexConfig,
   ): Index<T> => {
     throw new Error("Uncompiled index");

--- a/packages/framework/runtime/src/lib.ts
+++ b/packages/framework/runtime/src/lib.ts
@@ -65,7 +65,6 @@ export { Job } from "./job.ts";
 export type { Precache } from "./precache.ts";
 export {
   precacheFileName,
-  resolvePrecacheFile,
   parsePrecache,
   formatPrecache,
   createPrecache,

--- a/packages/framework/runtime/src/precache.ts
+++ b/packages/framework/runtime/src/precache.ts
@@ -1,5 +1,3 @@
-import { resolve as resolvePath } from "node:path";
-import type ts from "typescript";
 import YAML from "yaml";
 import type { EmbeddingVector, Embeddings } from "@toolcog/core";
 import { decodeEmbeddings, encodeEmbeddings } from "@toolcog/core";
@@ -9,17 +7,6 @@ interface Precache<V = EmbeddingVector> {
 }
 
 const precacheFileName = ".toolcog/precache.yaml";
-
-const resolvePrecacheFile = (
-  sourceFile: ts.SourceFile | undefined,
-  fileName: string = precacheFileName,
-): string | undefined => {
-  const packageDirectory = sourceFile?.packageJsonScope?.packageDirectory;
-  if (packageDirectory === undefined) {
-    return undefined;
-  }
-  return resolvePath(packageDirectory, fileName);
-};
 
 const parsePrecache = (yaml: string): Precache => {
   return decodePrecache(
@@ -54,10 +41,4 @@ const createPrecache = (): Precache => {
 };
 
 export type { Embeddings, Precache };
-export {
-  precacheFileName,
-  resolvePrecacheFile,
-  parsePrecache,
-  formatPrecache,
-  createPrecache,
-};
+export { precacheFileName, parsePrecache, formatPrecache, createPrecache };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ catalogs:
       specifier: ^3.1
       version: 3.1.6
     '@astrojs/starlight':
-      specifier: ^0.26
-      version: 0.26.4
+      specifier: ^0.27
+      version: 0.27.1
     astro:
       specifier: ^4.15
       version: 4.15.4
@@ -208,7 +208,7 @@ importers:
         version: 3.1.6
       '@astrojs/starlight':
         specifier: catalog:website
-        version: 0.26.4(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4))
+        version: 0.27.1(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4))
       astro:
         specifier: catalog:website
         version: 4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4)
@@ -235,10 +235,10 @@ importers:
         version: 0.33.5
       starlight-blog:
         specifier: catalog:website
-        version: 0.12.0(@astrojs/starlight@0.26.4(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4)))(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4))
+        version: 0.12.0(@astrojs/starlight@0.27.1(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4)))(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4))
       starlight-typedoc:
         specifier: catalog:website
-        version: 0.16.0(@astrojs/starlight@0.26.4(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4)))(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4))(typedoc-plugin-markdown@4.2.7(typedoc@0.26.6(typescript@5.5.4)))(typedoc@0.26.6(typescript@5.5.4))
+        version: 0.16.0(@astrojs/starlight@0.27.1(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4)))(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4))(typedoc-plugin-markdown@4.2.7(typedoc@0.26.6(typescript@5.5.4)))(typedoc@0.26.6(typescript@5.5.4))
       typedoc:
         specifier: catalog:build
         version: 0.26.6(typescript@5.5.4)
@@ -659,8 +659,8 @@ packages:
   '@astrojs/sitemap@3.1.6':
     resolution: {integrity: sha512-1Qp2NvAzVImqA6y+LubKi1DVhve/hXXgFvB0szxiipzh7BvtuKe4oJJ9dXSqaubaTkt4nMa6dv6RCCAYeB6xaQ==}
 
-  '@astrojs/starlight@0.26.4':
-    resolution: {integrity: sha512-ks+GAYkYGZxuCjAJR88HFafY4/K73PtkbYniGaptmdB0yDJY/HwJ/s1vIuig3j63oq9otQfuZFByxWsb4x1urg==}
+  '@astrojs/starlight@0.27.1':
+    resolution: {integrity: sha512-L2hEgN/Tk7tfBDeaqUOgOpey5NcUL78FuQa06iNxyZ6RjyYyuXSniOoFxZYIo5PpY9O1dLdK22PkZyCDpO729g==}
     peerDependencies:
       astro: ^4.8.6
 
@@ -1546,25 +1546,25 @@ packages:
   '@vitest/utils@2.0.5':
     resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
 
-  '@volar/kit@2.4.2':
-    resolution: {integrity: sha512-sHCJv/nd8ZYsP/WKoTIQTboKbJ4F7oerv6PJK/ji374JTn3fqNnp4EV0V+Iiw60V7oUOWozhh7k6nugUUYDFWg==}
+  '@volar/kit@2.4.4':
+    resolution: {integrity: sha512-6WusqQ4YhtIYbqY3nlLnkSbfBRSakx5HcTKdF+WjGKBj5D74ux9nsLq3uAqQlbpKgVkkt425KEDymQTb4C36Kg==}
     peerDependencies:
       typescript: '*'
 
-  '@volar/language-core@2.4.2':
-    resolution: {integrity: sha512-sONt5RLvLL1SlBdhyUSthZzuKePbJ7DwFFB9zT0eyWpDl+v7GXGh/RkPxxWaR22bIhYtTzp4Ka1MWatl/53Riw==}
+  '@volar/language-core@2.4.4':
+    resolution: {integrity: sha512-kO9k4kTLfxpg+6lq7/KAIv3m2d62IHuCL6GbVgYZTpfKvIGoAIlDxK7pFcB/eczN2+ydg/vnyaeZ6SGyZrJw2w==}
 
-  '@volar/language-server@2.4.2':
-    resolution: {integrity: sha512-BoGGGar5kzWnCxv41nnpplPQz+ntHgOSYshxH7CqNo5DOz5R3WXtkDA6T6bOpt70JeejoNyk/5kINV8KGeI17Q==}
+  '@volar/language-server@2.4.4':
+    resolution: {integrity: sha512-rBzTgRw4/msZSFRSJURFU53qcDfBNm40NtYoMwOyaZuPcLzdgDAZ3hzVE80Rj0pk82LQJ0AfH13Y+EYFvUWkfQ==}
 
-  '@volar/language-service@2.4.2':
-    resolution: {integrity: sha512-tJAfl1RouBcSPfgY7ivV/CWH6G/cOzwflMUFnfR7qTLZht7azx4CwlndiyGiL7lGcnfi7OZBKXd8Oqy9jhKZCA==}
+  '@volar/language-service@2.4.4':
+    resolution: {integrity: sha512-QXfZV3IpJdcNQcdWFEG+iXOIb3NiC6/cNIQeH2QAOMx2vpkshuMcWD7AzrhVavobircOXJNiGmRGwqf2okYE3A==}
 
-  '@volar/source-map@2.4.2':
-    resolution: {integrity: sha512-qiGfGgeZ5DEarPX3S+HcFktFCjfDrFPCXKeXNbrlB7v8cvtPRm8YVwoXOdGG1NhaL5rMlv5BZPVQyu4EdWWIvA==}
+  '@volar/source-map@2.4.4':
+    resolution: {integrity: sha512-xG3PZqOP2haG8XG4Pg3PD1UGDAdqZg24Ru8c/qYjYAnmcj6GBR64mstx+bZux5QOyRaJK+/lNM/RnpvBD3489g==}
 
-  '@volar/typescript@2.4.2':
-    resolution: {integrity: sha512-m2uZduhaHO1SZuagi30OsjI/X1gwkaEAC+9wT/nCNAtJ5FqXEkKvUncHmffG7ESDZPlFFUBK4vJ0D9Hfr+f2EA==}
+  '@volar/typescript@2.4.4':
+    resolution: {integrity: sha512-QQMQRVj0fVHJ3XdRKiS1LclhG0VBXdFYlyuHRQF/xLk2PuJuHNWP26MDZNvEVCvnyUQuUQhIAfylwY5TGPgc6w==}
 
   '@vscode/emmet-helper@2.9.3':
     resolution: {integrity: sha512-rB39LHWWPQYYlYfpv9qCoZOVioPCftKXXqrsyqN1mTWZM6dTnONT63Db+03vgrBbHzJN45IrgS/AGxw9iiqfEw==}
@@ -1980,8 +1980,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  electron-to-chromium@1.5.17:
-    resolution: {integrity: sha512-Q6Q+04tjC2KJ8qsSOSgovvhWcv5t+SmpH6/YfAWmhpE5/r+zw6KQy1/yWVFFNyEBvy68twTTXr2d5eLfCq7QIw==}
+  electron-to-chromium@1.5.18:
+    resolution: {integrity: sha512-1OfuVACu+zKlmjsNdcJuVQuVE61sZOLbNM4JAQ1Rvh6EOj0/EUKhMJjRH73InPlXSh8HIJk1cVZ8pyOV/FMdUQ==}
 
   emmet@2.4.7:
     resolution: {integrity: sha512-O5O5QNqtdlnQM2bmKHtJgyChcrFMgQuulI+WdiOw2NArzprUqqxUW6bgYtKvzKgrsYpuLWalOkdhNP+1jluhCA==}
@@ -3154,6 +3154,11 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
   prettier@3.3.3:
     resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
     engines: {node: '>=14'}
@@ -3405,8 +3410,8 @@ packages:
     resolution: {integrity: sha512-TzobUYoEft/xBtb2voRPryAUIvYguG0V7Tt3de79I1WfXgCwelqVsGuZSnu3GFGRZhXR90AeEYIM+icuB/S06Q==}
     hasBin: true
 
-  source-map-js@1.2.0:
-    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
   source-map@0.7.4:
@@ -4075,20 +4080,20 @@ snapshots:
       '@astrojs/compiler': 2.10.3
       '@astrojs/yaml2ts': 0.2.1
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@volar/kit': 2.4.2(typescript@5.5.4)
-      '@volar/language-core': 2.4.2
-      '@volar/language-server': 2.4.2
-      '@volar/language-service': 2.4.2
-      '@volar/typescript': 2.4.2
+      '@volar/kit': 2.4.4(typescript@5.5.4)
+      '@volar/language-core': 2.4.4
+      '@volar/language-server': 2.4.4
+      '@volar/language-service': 2.4.4
+      '@volar/typescript': 2.4.4
       fast-glob: 3.3.2
       muggle-string: 0.4.1
-      volar-service-css: 0.0.61(@volar/language-service@2.4.2)
-      volar-service-emmet: 0.0.61(@volar/language-service@2.4.2)
-      volar-service-html: 0.0.61(@volar/language-service@2.4.2)
-      volar-service-prettier: 0.0.61(@volar/language-service@2.4.2)(prettier@3.3.3)
-      volar-service-typescript: 0.0.61(@volar/language-service@2.4.2)
-      volar-service-typescript-twoslash-queries: 0.0.61(@volar/language-service@2.4.2)
-      volar-service-yaml: 0.0.61(@volar/language-service@2.4.2)
+      volar-service-css: 0.0.61(@volar/language-service@2.4.4)
+      volar-service-emmet: 0.0.61(@volar/language-service@2.4.4)
+      volar-service-html: 0.0.61(@volar/language-service@2.4.4)
+      volar-service-prettier: 0.0.61(@volar/language-service@2.4.4)(prettier@3.3.3)
+      volar-service-typescript: 0.0.61(@volar/language-service@2.4.4)
+      volar-service-typescript-twoslash-queries: 0.0.61(@volar/language-service@2.4.4)
+      volar-service-yaml: 0.0.61(@volar/language-service@2.4.4)
       vscode-html-languageservice: 5.3.1
       vscode-uri: 3.0.8
     optionalDependencies:
@@ -4155,7 +4160,7 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.23.8
 
-  '@astrojs/starlight@0.26.4(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4))':
+  '@astrojs/starlight@0.27.1(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4))':
     dependencies:
       '@astrojs/mdx': 3.1.5(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4))
       '@astrojs/sitemap': 3.1.6
@@ -4348,7 +4353,7 @@ snapshots:
       fs-extra: 7.0.1
       lodash.startcase: 4.4.0
       outdent: 0.5.0
-      prettier: 2.8.7
+      prettier: 2.8.8
       resolve-from: 5.0.0
       semver: 7.6.3
 
@@ -4493,7 +4498,7 @@ snapshots:
       '@changesets/types': 6.0.0
       fs-extra: 7.0.1
       human-id: 1.0.2
-      prettier: 2.8.7
+      prettier: 2.8.8
 
   '@ctrl/tinycolor@4.1.0': {}
 
@@ -5189,24 +5194,24 @@ snapshots:
       loupe: 3.1.1
       tinyrainbow: 1.2.0
 
-  '@volar/kit@2.4.2(typescript@5.5.4)':
+  '@volar/kit@2.4.4(typescript@5.5.4)':
     dependencies:
-      '@volar/language-service': 2.4.2
-      '@volar/typescript': 2.4.2
+      '@volar/language-service': 2.4.4
+      '@volar/typescript': 2.4.4
       typesafe-path: 0.2.2
       typescript: 5.5.4
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.0.8
 
-  '@volar/language-core@2.4.2':
+  '@volar/language-core@2.4.4':
     dependencies:
-      '@volar/source-map': 2.4.2
+      '@volar/source-map': 2.4.4
 
-  '@volar/language-server@2.4.2':
+  '@volar/language-server@2.4.4':
     dependencies:
-      '@volar/language-core': 2.4.2
-      '@volar/language-service': 2.4.2
-      '@volar/typescript': 2.4.2
+      '@volar/language-core': 2.4.4
+      '@volar/language-service': 2.4.4
+      '@volar/typescript': 2.4.4
       path-browserify: 1.0.1
       request-light: 0.7.0
       vscode-languageserver: 9.0.1
@@ -5214,18 +5219,18 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.0.8
 
-  '@volar/language-service@2.4.2':
+  '@volar/language-service@2.4.4':
     dependencies:
-      '@volar/language-core': 2.4.2
+      '@volar/language-core': 2.4.4
       vscode-languageserver-protocol: 3.17.5
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.0.8
 
-  '@volar/source-map@2.4.2': {}
+  '@volar/source-map@2.4.4': {}
 
-  '@volar/typescript@2.4.2':
+  '@volar/typescript@2.4.4':
     dependencies:
-      '@volar/language-core': 2.4.2
+      '@volar/language-core': 2.4.4
       path-browserify: 1.0.1
       vscode-uri: 3.0.8
 
@@ -5492,7 +5497,7 @@ snapshots:
   browserslist@4.23.3:
     dependencies:
       caniuse-lite: 1.0.30001658
-      electron-to-chromium: 1.5.17
+      electron-to-chromium: 1.5.18
       node-releases: 2.0.18
       update-browserslist-db: 1.1.0(browserslist@4.23.3)
 
@@ -5695,7 +5700,7 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  electron-to-chromium@1.5.17: {}
+  electron-to-chromium@1.5.18: {}
 
   emmet@2.4.7:
     dependencies:
@@ -6519,7 +6524,7 @@ snapshots:
     dependencies:
       '@babel/parser': 7.25.6
       '@babel/types': 7.25.6
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
 
   markdown-extensions@2.0.0: {}
 
@@ -7265,7 +7270,7 @@ snapshots:
     dependencies:
       nanoid: 3.3.7
       picocolors: 1.1.0
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
 
   preferred-pm@4.0.0:
     dependencies:
@@ -7281,7 +7286,10 @@ snapshots:
       prettier: 3.3.3
       sass-formatter: 0.7.9
 
-  prettier@2.8.7: {}
+  prettier@2.8.7:
+    optional: true
+
+  prettier@2.8.8: {}
 
   prettier@3.3.3: {}
 
@@ -7625,7 +7633,7 @@ snapshots:
 
   smartypants@0.2.2: {}
 
-  source-map-js@1.2.0: {}
+  source-map-js@1.2.1: {}
 
   source-map@0.7.4: {}
 
@@ -7649,10 +7657,10 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  starlight-blog@0.12.0(@astrojs/starlight@0.26.4(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4)))(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4)):
+  starlight-blog@0.12.0(@astrojs/starlight@0.27.1(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4)))(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4)):
     dependencies:
       '@astrojs/rss': 4.0.5
-      '@astrojs/starlight': 0.26.4(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4))
+      '@astrojs/starlight': 0.27.1(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4))
       astro: 4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4)
       astro-remote: 0.3.2
       github-slugger: 2.0.0
@@ -7660,9 +7668,9 @@ snapshots:
       marked-plaintify: 1.0.1(marked@12.0.2)
       ultrahtml: 1.5.3
 
-  starlight-typedoc@0.16.0(@astrojs/starlight@0.26.4(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4)))(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4))(typedoc-plugin-markdown@4.2.7(typedoc@0.26.6(typescript@5.5.4)))(typedoc@0.26.6(typescript@5.5.4)):
+  starlight-typedoc@0.16.0(@astrojs/starlight@0.27.1(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4)))(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4))(typedoc-plugin-markdown@4.2.7(typedoc@0.26.6(typescript@5.5.4)))(typedoc@0.26.6(typescript@5.5.4)):
     dependencies:
-      '@astrojs/starlight': 0.26.4(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4))
+      '@astrojs/starlight': 0.27.1(astro@4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4))
       astro: 4.15.4(@types/node@22.5.4)(rollup@4.21.2)(typescript@5.5.4)
       github-slugger: 2.0.0
       typedoc: 0.26.6(typescript@5.5.4)
@@ -8017,45 +8025,45 @@ snapshots:
       - supports-color
       - terser
 
-  volar-service-css@0.0.61(@volar/language-service@2.4.2):
+  volar-service-css@0.0.61(@volar/language-service@2.4.4):
     dependencies:
       vscode-css-languageservice: 6.3.1
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.0.8
     optionalDependencies:
-      '@volar/language-service': 2.4.2
+      '@volar/language-service': 2.4.4
 
-  volar-service-emmet@0.0.61(@volar/language-service@2.4.2):
+  volar-service-emmet@0.0.61(@volar/language-service@2.4.4):
     dependencies:
       '@emmetio/css-parser': 0.4.0
       '@emmetio/html-matcher': 1.3.0
       '@vscode/emmet-helper': 2.9.3
       vscode-uri: 3.0.8
     optionalDependencies:
-      '@volar/language-service': 2.4.2
+      '@volar/language-service': 2.4.4
 
-  volar-service-html@0.0.61(@volar/language-service@2.4.2):
+  volar-service-html@0.0.61(@volar/language-service@2.4.4):
     dependencies:
       vscode-html-languageservice: 5.3.1
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.0.8
     optionalDependencies:
-      '@volar/language-service': 2.4.2
+      '@volar/language-service': 2.4.4
 
-  volar-service-prettier@0.0.61(@volar/language-service@2.4.2)(prettier@3.3.3):
+  volar-service-prettier@0.0.61(@volar/language-service@2.4.4)(prettier@3.3.3):
     dependencies:
       vscode-uri: 3.0.8
     optionalDependencies:
-      '@volar/language-service': 2.4.2
+      '@volar/language-service': 2.4.4
       prettier: 3.3.3
 
-  volar-service-typescript-twoslash-queries@0.0.61(@volar/language-service@2.4.2):
+  volar-service-typescript-twoslash-queries@0.0.61(@volar/language-service@2.4.4):
     dependencies:
       vscode-uri: 3.0.8
     optionalDependencies:
-      '@volar/language-service': 2.4.2
+      '@volar/language-service': 2.4.4
 
-  volar-service-typescript@0.0.61(@volar/language-service@2.4.2):
+  volar-service-typescript@0.0.61(@volar/language-service@2.4.4):
     dependencies:
       path-browserify: 1.0.1
       semver: 7.6.3
@@ -8064,14 +8072,14 @@ snapshots:
       vscode-nls: 5.2.0
       vscode-uri: 3.0.8
     optionalDependencies:
-      '@volar/language-service': 2.4.2
+      '@volar/language-service': 2.4.4
 
-  volar-service-yaml@0.0.61(@volar/language-service@2.4.2):
+  volar-service-yaml@0.0.61(@volar/language-service@2.4.4):
     dependencies:
       vscode-uri: 3.0.8
       yaml-language-server: 1.15.0
     optionalDependencies:
-      '@volar/language-service': 2.4.2
+      '@volar/language-service': 2.4.4
 
   vscode-css-languageservice@6.3.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,7 +50,7 @@ catalogs:
     "@astrojs/check": ^0.9
     "@astrojs/mdx": ^3.1
     "@astrojs/sitemap": ^3.1
-    "@astrojs/starlight": ^0.26
+    "@astrojs/starlight": ^0.27
     astro: ^4.15
     astro-expressive-code: ^0.36
     eslint-plugin-astro: ^1.2

--- a/rollup.js
+++ b/rollup.js
@@ -16,6 +16,7 @@ const defineLib = (options = {}) => {
     exports,
     exportConditions,
     external = [/^@?toolcog\//],
+    transformers,
     plugins,
   } = options;
 
@@ -85,7 +86,9 @@ const defineLib = (options = {}) => {
           extensions: [".js", ".ts"],
           exportConditions,
         }),
-        typescript(),
+        typescript({
+          transformers,
+        }),
         ...(replaceOptions !== undefined ? [replace(replaceOptions)] : []),
         ...(plugins ?? []),
       ],


### PR DESCRIPTION
Source node ID generation previously relied on the typescript compiler having already defined `ts.Node.packageJsonScope`, which is not the case when the transformer is invoked by e.g. @rollup/plugin-typescript. This caused missing package names and incorrect relative module paths when generating unique source node IDs.

`packageJsonScope` is now resolved with `ts.getPackageScopeForPath` when not already defined. Source node ID generation also now delegates to `ts.getExternalModuleNameFromPath` to determine the relative module paths.

`@id` doc tags can now be used to override automatic source node ID generation. `@noid` doc tags can also now be used to prevent enclosing named blocks from being included in generated source node IDs.

Parsed toolcog comments are now cached by `getCommentForNode`.

The parameter type of the `defineIndex` intrinsic now properly reflects the fact that it can be called with an array of pre-generated idioms.

Removed the unused `resolvePrecacheFile` function.