### PR TITLE
Implement JSON schema validation, matching, and subtyping

### DIFF
--- a/.changeset/tasty-cameras-speak.md
+++ b/.changeset/tasty-cameras-speak.md
@@ -1,0 +1,13 @@
+---
+"@toolcog/util": patch
+---
+
+Implement JSON schema validation, matching, and subtyping
+
+The `validate` function checks if a given value conforms to a schema object.
+The `isSubschema` function checks if one subschema represents a subtype of
+another schema. The `matchSchema` function returns the most specific subschema
+that matches a given value. When multiple subschemas match.
+
+The `formatJson` function now uses `matchSchema` internally to splice in
+descriptive comments for a polymorphic value's most specific subtype.

--- a/packages/framework/util/json/src/format.test.ts
+++ b/packages/framework/util/json/src/format.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "vitest";
+import type { Schema } from "./schema.ts";
 import { formatJson } from "./format.ts";
 
 it("should format void values with descriptive schemas", () => {
@@ -6,7 +7,7 @@ it("should format void values with descriptive schemas", () => {
   const schema = {
     type: "void",
     description: "Does not exist.",
-  } as const;
+  } as const satisfies Schema;
 
   expect(formatJson(value, schema)).toEqual(
     "// Does not exist.\n" + "undefined",
@@ -18,7 +19,7 @@ it("should format undefined values with descriptive schemas", () => {
   const schema = {
     type: "undefined",
     description: "Not a defined value.",
-  } as const;
+  } as const satisfies Schema;
 
   expect(formatJson(value, schema)).toEqual(
     "// Not a defined value.\n" + "undefined",
@@ -30,7 +31,7 @@ it("should format null values with descriptive schemas", () => {
   const schema = {
     type: "null",
     description: "Not a real value.",
-  } as const;
+  } as const satisfies Schema;
 
   expect(formatJson(value, schema)).toEqual("// Not a real value.\n" + "null");
 });
@@ -40,7 +41,7 @@ it("should format boolean values with descriptive schemas", () => {
   const schema = {
     type: "boolean",
     description: "Maybe, maybe not.",
-  } as const;
+  } as const satisfies Schema;
 
   expect(formatJson(value, schema)).toEqual("// Maybe, maybe not.\n" + "true");
 });
@@ -50,7 +51,7 @@ it("should format number values with descriptive schemas", () => {
   const schema = {
     type: "number",
     description: "The ratio of a circle's circumference to its diameter.",
-  } as const;
+  } as const satisfies Schema;
 
   expect(formatJson(value, schema)).toEqual(
     "// The ratio of a circle's circumference to its diameter.\n" + "3.14",
@@ -62,7 +63,7 @@ it("should format string values with descriptive schemas", () => {
   const schema = {
     type: "string",
     description: "A pleasant greeting.",
-  } as const;
+  } as const satisfies Schema;
 
   expect(formatJson(value, schema)).toEqual(
     "// A pleasant greeting.\n" + '"Hello, world!"',
@@ -74,7 +75,7 @@ it("should format empty arrays with descriptive schemas", () => {
   const schema = {
     type: "array",
     description: "An empty container.",
-  } as const;
+  } as const satisfies Schema;
 
   expect(formatJson(value, schema)).toEqual("// An empty container.\n" + "[]");
 });
@@ -87,7 +88,7 @@ it("should format arrays with nondescript item schemas", () => {
     items: {
       type: "integer",
     },
-  } as const;
+  } as const satisfies Schema;
 
   expect(formatJson(value, schema)).toEqual(
     "// The cardinal numbers.\n" + "[\n" + "  1,\n" + "  2,\n" + "  3,\n" + "]",
@@ -103,7 +104,7 @@ it("should format arrays with descriptive item schemas", () => {
       type: "integer",
       description: "The next integer.",
     },
-  } as const;
+  } as const satisfies Schema;
 
   expect(formatJson(value, schema)).toEqual(
     "// The cardinal numbers.\n" +
@@ -133,7 +134,7 @@ it("should format tuples with descriptive item schemas", () => {
         description: "The ordinal number word.",
       },
     ],
-  } as const;
+  } as const satisfies Schema;
 
   expect(formatJson(value, schema)).toEqual(
     "// An ordinal numeral mapping.\n" +
@@ -151,7 +152,7 @@ it("should format empty objects with descriptive schemas", () => {
   const schema = {
     type: "object",
     description: "An empty vessel.",
-  } as const;
+  } as const satisfies Schema;
 
   expect(formatJson(value, schema)).toEqual("// An empty vessel.\n" + "{}");
 });
@@ -172,7 +173,7 @@ it("should format objects with nondescript property schemas", () => {
         type: "number",
       },
     },
-  } as const;
+  } as const satisfies Schema;
 
   expect(formatJson(value, schema)).toEqual(
     "// A point in space.\n" +
@@ -203,7 +204,7 @@ it("should format objects with descriptive property schemas", () => {
         description: "The third dimension.",
       },
     },
-  } as const;
+  } as const satisfies Schema;
 
   expect(formatJson(value, schema)).toEqual(
     "// A point on the plane.\n" +
@@ -274,7 +275,7 @@ it("should format complex objects with descriptive schemas", () => {
         ],
       },
     },
-  } as const;
+  } as const satisfies Schema;
 
   expect(formatJson(value, schema)).toEqual(
     "// A point of interest.\n" +
@@ -300,5 +301,26 @@ it("should format complex objects with descriptive schemas", () => {
       "    36.6181,\n" +
       "  ],\n" +
       "}",
+  );
+});
+
+it("should format values with the most specific matching subschema", () => {
+  const value = 15;
+  const schema = {
+    anyOf: [
+      {
+        type: "string",
+        description: "A string value.",
+      },
+      {
+        type: "number",
+        minimum: 10,
+        description: "A number greater than or equal to 10.",
+      },
+    ],
+  } as const satisfies Schema;
+
+  expect(formatJson(value, schema)).toEqual(
+    "// A number greater than or equal to 10.\n" + "15",
   );
 });

--- a/packages/framework/util/json/src/format.ts
+++ b/packages/framework/util/json/src/format.ts
@@ -1,5 +1,6 @@
 import { replaceLines } from "@toolcog/util";
 import type { SchemaDefinition, Schema } from "./schema.ts";
+import { matchSchema } from "./match.ts";
 
 interface FormatJsonOptions {
   indent?: number | undefined;
@@ -27,6 +28,10 @@ const formatJsonValue = (
   const indentation = " ".repeat(indent);
 
   let json = "";
+
+  if (schema !== undefined) {
+    schema = matchSchema(value, schema);
+  }
 
   if (typeof schema === "object" && schema.description !== undefined) {
     json +=

--- a/packages/framework/util/json/src/match.test.ts
+++ b/packages/framework/util/json/src/match.test.ts
@@ -1,0 +1,24 @@
+import { expect, it } from "vitest";
+import type { Schema } from "./schema.ts";
+import { matchSchema } from "./match.ts";
+
+it("should return the matching subschema when exactly one matches", () => {
+  const schema = {
+    anyOf: [{ type: "string" }, { type: "number", minimum: 10 }],
+  } as const satisfies Schema;
+  expect(matchSchema(15, schema)).toBe(schema.anyOf[1]);
+});
+
+it("should return the most specific subschema when multiple match", () => {
+  const schema = {
+    anyOf: [{ type: "number" }, { minimum: 0 }],
+  } as const satisfies Schema;
+  expect(matchSchema(5, schema)).toBe(schema.anyOf[0]);
+});
+
+it("should return undefined when no subschemas match", () => {
+  const schema = {
+    anyOf: [{ type: "string" }, { type: "array" }],
+  } as const satisfies Schema;
+  expect(matchSchema(42, schema)).toBeUndefined();
+});

--- a/packages/framework/util/json/src/match.ts
+++ b/packages/framework/util/json/src/match.ts
@@ -1,0 +1,124 @@
+import type { SchemaDefinition, Schema } from "./schema.ts";
+import { isSubschema } from "./subschema.ts";
+import { validate } from "./validate.ts";
+
+const matchSchema: {
+  (value: unknown, schema: Schema): Schema | undefined;
+  (value: unknown, schema: SchemaDefinition): SchemaDefinition | undefined;
+} = ((
+  value: unknown,
+  schema: SchemaDefinition,
+): SchemaDefinition | undefined => {
+  if (typeof schema === "boolean") {
+    return schema ? schema : undefined;
+  }
+
+  if (schema.$ref !== undefined) {
+    throw new Error("$ref is not supported");
+  }
+
+  if (schema.not !== undefined) {
+    if (validate(value, schema.not)) {
+      return undefined;
+    }
+  }
+
+  if (schema.if !== undefined) {
+    if (validate(value, schema.if)) {
+      if (schema.then !== undefined) {
+        return matchSchema(value, schema.then);
+      }
+    } else {
+      if (schema.else !== undefined) {
+        return matchSchema(value, schema.else);
+      }
+    }
+  }
+
+  if (schema.allOf !== undefined) {
+    for (const subschema of schema.allOf) {
+      if (!validate(value, subschema)) {
+        return undefined;
+      }
+    }
+    return schema;
+  }
+
+  if (schema.oneOf !== undefined) {
+    const matchingSchemas = matchSchemas(value, schema.oneOf);
+    if (matchingSchemas.length === 1) {
+      return matchSchema(value, matchingSchemas[0]!);
+    } else if (matchingSchemas.length > 1) {
+      return schema;
+    }
+    return undefined;
+  }
+
+  if (schema.anyOf !== undefined) {
+    const matchingSchemas = matchSchemas(value, schema.anyOf);
+    if (matchingSchemas.length === 1) {
+      const subschema = matchSchema(value, matchingSchemas[0]!);
+      return schema.description === undefined || isSpecific(subschema) ?
+          subschema
+        : schema;
+    } else if (matchingSchemas.length > 1) {
+      return schema;
+    }
+    return undefined;
+  }
+
+  if (validate(value, schema)) {
+    return schema;
+  }
+
+  return undefined;
+}) as typeof matchSchema;
+
+const matchSchemas: {
+  (value: unknown, schemas: readonly Schema[]): Schema[];
+  (value: unknown, schemas: readonly SchemaDefinition[]): SchemaDefinition[];
+} = ((
+  value: unknown,
+  schemas: readonly SchemaDefinition[],
+): SchemaDefinition[] => {
+  const matchingSchemas = schemas.filter((schema) => validate(value, schema));
+  if (matchingSchemas.length === 0) {
+    return [];
+  } else if (matchingSchemas.length === 1) {
+    return matchingSchemas;
+  }
+
+  // Find any schemas that are subtypes of all other matching schemas.
+  const bestSchemas = matchingSchemas.filter((candidateSchema) =>
+    matchingSchemas.every(
+      (otherSchema) =>
+        candidateSchema === otherSchema ||
+        isSubschema(candidateSchema, otherSchema),
+    ),
+  );
+  return bestSchemas.length === 1 ? bestSchemas : matchingSchemas;
+}) as typeof matchSchemas;
+
+const isSpecific = (schema: SchemaDefinition | undefined): boolean => {
+  if (schema === undefined || typeof schema === "boolean") {
+    return false;
+  } else if (schema.description !== undefined) {
+    return true;
+  } else if (schema.const !== undefined) {
+    return false;
+  }
+  switch (schema.type) {
+    case "void":
+    case "undefined":
+    case "null":
+    case "boolean":
+    case "integer":
+    case "number":
+    case "string":
+      return false;
+    default:
+      return true;
+  }
+};
+
+export { matchSchema, matchSchemas };

--- a/packages/framework/util/json/src/mod.ts
+++ b/packages/framework/util/json/src/mod.ts
@@ -7,5 +7,11 @@ export type {
   FunctionSchema,
 } from "./schema.ts";
 
+export { isSubschema } from "./subschema.ts";
+
+export { validate } from "./validate.ts";
+
+export { matchSchema } from "./match.ts";
+
 export type { FormatJsonOptions } from "./format.ts";
 export { formatJson } from "./format.ts";

--- a/packages/framework/util/json/src/subschema.test.ts
+++ b/packages/framework/util/json/src/subschema.test.ts
@@ -1,0 +1,514 @@
+import { describe, it, expect } from "vitest";
+import type { SchemaDefinition, Schema } from "./schema.ts";
+import { isSubschema } from "./subschema.ts";
+
+describe("schema type subtyping", () => {
+  it("should return true when types are the same", () => {
+    const subschema = { type: "number" } as const satisfies Schema;
+    const superSchema = { type: "number" } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return true when subschema type is a subset of superSchema type", () => {
+    const subschema = { type: "integer" } as const satisfies Schema;
+    const superSchema = { type: "number" } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema type is not a subset of superSchema type", () => {
+    const subschema = { type: "number" } as const satisfies Schema;
+    const superSchema = { type: "integer" } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should handle multiple types in subschema and superSchema", () => {
+    const subschema = { type: ["integer", "string"] } as const satisfies Schema;
+    const superSchema = {
+      type: ["number", "string", "boolean"],
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema has types not present in superSchema", () => {
+    const subschema = {
+      type: ["integer", "string", "boolean"],
+    } as const satisfies Schema;
+    const superSchema = {
+      type: ["number", "string"],
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should return true when superSchema type is undefined", () => {
+    const subschema = { type: "string" } as const satisfies Schema;
+    const superSchema = {} as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema type is undefined and superSchema type is defined", () => {
+    const subschema = {} as const satisfies Schema;
+    const superSchema = { type: "string" } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+});
+
+describe("enum and const subtyping", () => {
+  it("should return true when subschema enum is a subset of superSchema enum", () => {
+    const subschema = { enum: [1, 2] } as const satisfies Schema;
+    const superSchema = { enum: [1, 2, 3] } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema enum is not a subset of superSchema enum", () => {
+    const subschema = { enum: [1, 4] } as const satisfies Schema;
+    const superSchema = { enum: [1, 2, 3] } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should return true when subschema const equals superSchema const", () => {
+    const subschema = { const: "value" } as const satisfies Schema;
+    const superSchema = { const: "value" } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema const does not equal superSchema const", () => {
+    const subschema = { const: "value1" } as const satisfies Schema;
+    const superSchema = { const: "value2" } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should return true when subschema const is in superSchema enum", () => {
+    const subschema = { const: 2 } as const satisfies Schema;
+    const superSchema = { enum: [1, 2, 3] } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema const is not in superSchema enum", () => {
+    const subschema = { const: 4 } as const satisfies Schema;
+    const superSchema = { enum: [1, 2, 3] } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should return true when superSchema enum is undefined", () => {
+    const subschema = { enum: [1, 2] } as const satisfies Schema;
+    const superSchema = {} as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+});
+
+describe("numeric constraint subtyping", () => {
+  it("should return true when subschema minimum is greater than superSchema minimum", () => {
+    const subschema = { type: "number", minimum: 5 } as const satisfies Schema;
+    const superSchema = {
+      type: "number",
+      minimum: 0,
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema minimum is less than superSchema minimum", () => {
+    const subschema = { type: "number", minimum: 0 } as const satisfies Schema;
+    const superSchema = {
+      type: "number",
+      minimum: 5,
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should return true when subschema maximum is less than superSchema maximum", () => {
+    const subschema = { type: "number", maximum: 10 } as const satisfies Schema;
+    const superSchema = {
+      type: "number",
+      maximum: 15,
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema maximum is greater than superSchema maximum", () => {
+    const subschema = { type: "number", maximum: 20 } as const satisfies Schema;
+    const superSchema = {
+      type: "number",
+      maximum: 15,
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should return true when subschema multipleOf is a multiple of superSchema multipleOf", () => {
+    const subschema = {
+      type: "number",
+      multipleOf: 4,
+    } as const satisfies Schema;
+    const superSchema = {
+      type: "number",
+      multipleOf: 2,
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema multipleOf is not a multiple of superSchema multipleOf", () => {
+    const subschema = {
+      type: "number",
+      multipleOf: 3,
+    } as const satisfies Schema;
+    const superSchema = {
+      type: "number",
+      multipleOf: 2,
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+});
+
+describe("string constraint subtyping", () => {
+  it("should return true when subschema minLength is greater than superSchema minLength", () => {
+    const subschema = {
+      type: "string",
+      minLength: 5,
+    } as const satisfies Schema;
+    const superSchema = {
+      type: "string",
+      minLength: 3,
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema minLength is less than superSchema minLength", () => {
+    const subschema = {
+      type: "string",
+      minLength: 2,
+    } as const satisfies Schema;
+    const superSchema = {
+      type: "string",
+      minLength: 3,
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should return true when subschema maxLength is less than superSchema maxLength", () => {
+    const subschema = {
+      type: "string",
+      maxLength: 5,
+    } as const satisfies Schema;
+    const superSchema = {
+      type: "string",
+      maxLength: 10,
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema maxLength is greater than superSchema maxLength", () => {
+    const subschema = {
+      type: "string",
+      maxLength: 15,
+    } as const satisfies Schema;
+    const superSchema = {
+      type: "string",
+      maxLength: 10,
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should return true when subschema pattern equals superSchema pattern", () => {
+    const subschema = {
+      type: "string",
+      pattern: "^abc$",
+    } as const satisfies Schema;
+    const superSchema = {
+      type: "string",
+      pattern: "^abc$",
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema pattern does not equal superSchema pattern", () => {
+    const subschema = {
+      type: "string",
+      pattern: "^abc$",
+    } as const satisfies Schema;
+    const superSchema = {
+      type: "string",
+      pattern: "^abcd$",
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should return true when superSchema pattern is undefined", () => {
+    const subschema = {
+      type: "string",
+      pattern: "^abc$",
+    } as const satisfies Schema;
+    const superSchema = { type: "string" } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+});
+
+describe("array constraint subtyping", () => {
+  it("should return true when subschema minItems is greater than superSchema minItems", () => {
+    const subschema = { type: "array", minItems: 3 } as const satisfies Schema;
+    const superSchema = {
+      type: "array",
+      minItems: 2,
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema minItems is less than superSchema minItems", () => {
+    const subschema = { type: "array", minItems: 1 } as const satisfies Schema;
+    const superSchema = {
+      type: "array",
+      minItems: 2,
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should return true when subschema maxItems is less than superSchema maxItems", () => {
+    const subschema = { type: "array", maxItems: 5 } as const satisfies Schema;
+    const superSchema = {
+      type: "array",
+      maxItems: 10,
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema maxItems is greater than superSchema maxItems", () => {
+    const subschema = { type: "array", maxItems: 15 } as const satisfies Schema;
+    const superSchema = {
+      type: "array",
+      maxItems: 10,
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should return true when subschema items is a subtype of superSchema items", () => {
+    const subschema = {
+      type: "array",
+      items: { type: "integer" },
+    } as const satisfies Schema;
+    const superSchema = {
+      type: "array",
+      items: { type: "number" },
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema items is not a subtype of superSchema items", () => {
+    const subschema = {
+      type: "array",
+      items: { type: "number" },
+    } as const satisfies Schema;
+    const superSchema = {
+      type: "array",
+      items: { type: "integer" },
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should return true when subschema additionalItems is false and superSchema additionalItems is true", () => {
+    const subschema = {
+      type: "array",
+      items: [{ type: "string" }],
+      additionalItems: false,
+    } as const satisfies Schema;
+    const superSchema = {
+      type: "array",
+      items: [{ type: "string" }],
+      additionalItems: true,
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema additionalItems is true and superSchema additionalItems is false", () => {
+    const subschema = {
+      type: "array",
+      items: [{ type: "string" }],
+      additionalItems: true,
+    } as const satisfies Schema;
+    const superSchema = {
+      type: "array",
+      items: [{ type: "string" }],
+      additionalItems: false,
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+});
+
+describe("object constraint subtyping", () => {
+  it("should return true when subschema required includes superSchema required", () => {
+    const subschema = {
+      type: "object",
+      required: ["a", "b", "c"],
+    } as const satisfies Schema;
+    const superSchema = {
+      type: "object",
+      required: ["a", "b"],
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema required does not include superSchema required", () => {
+    const subschema = {
+      type: "object",
+      required: ["a", "b"],
+    } as const satisfies Schema;
+    const superSchema = {
+      type: "object",
+      required: ["a", "b", "c"],
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should return true when subschema properties are subtypes of superSchema properties", () => {
+    const subschema = {
+      type: "object",
+      properties: {
+        age: { type: "integer", minimum: 18 },
+      },
+    } as const satisfies Schema;
+    const superSchema = {
+      type: "object",
+      properties: {
+        age: { type: "number", minimum: 0 },
+      },
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema properties are not subtypes of superSchema properties", () => {
+    const subschema = {
+      type: "object",
+      properties: {
+        age: { type: "number", minimum: 0 },
+      },
+    } as const satisfies Schema;
+    const superSchema = {
+      type: "object",
+      properties: {
+        age: { type: "integer", minimum: 18 },
+      },
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should return true when subschema additionalProperties is false and superSchema additionalProperties is true", () => {
+    const subschema = {
+      type: "object",
+      properties: { name: { type: "string" } },
+      additionalProperties: false,
+    } as const satisfies Schema;
+    const superSchema = {
+      type: "object",
+      properties: { name: { type: "string" } },
+      additionalProperties: true,
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema additionalProperties is true and superSchema additionalProperties is false", () => {
+    const subschema = {
+      type: "object",
+      properties: { name: { type: "string" } },
+      additionalProperties: true,
+    } as const satisfies Schema;
+    const superSchema = {
+      type: "object",
+      properties: { name: { type: "string" } },
+      additionalProperties: false,
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+});
+
+describe("logical constraint subtyping", () => {
+  it("should return false when subschema allOf is not a subtype of superSchema allOf", () => {
+    const subschema = {
+      allOf: [{ type: "integer" }, { minimum: 10 }],
+    } as const satisfies Schema;
+    const superSchema = {
+      allOf: [{ type: "number" }, { minimum: 0 }],
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should return false when subschema allOf is not a subtype of superSchema allOf", () => {
+    const subschema = {
+      allOf: [{ type: "integer" }, { minimum: 10 }],
+    } as const satisfies Schema;
+    const superSchema = {
+      allOf: [{ type: "number" }, { minimum: 0 }],
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should return true when subschema anyOf is a subtype of superSchema anyOf", () => {
+    const subschema = {
+      anyOf: [{ type: "integer" }, { type: "string" }],
+    } as const satisfies Schema;
+    const superSchema = {
+      anyOf: [{ type: "number" }, { type: "string" }, { type: "boolean" }],
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema anyOf is not a subtype of superSchema anyOf", () => {
+    const subschema = {
+      anyOf: [{ type: "integer" }, { type: "boolean" }],
+    } as const satisfies Schema;
+    const superSchema = {
+      anyOf: [{ type: "number" }, { type: "string" }],
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should return false when subschema not is not a subtype of superSchema not", () => {
+    const subschema = { not: { type: "string" } } as const satisfies Schema;
+    const superSchema = {
+      not: { type: ["string", "boolean"] },
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should return false when subschema not is not a subtype of superSchema not", () => {
+    const subschema = { not: { type: "number" } } as const satisfies Schema;
+    const superSchema = {
+      not: { type: ["string", "boolean"] },
+    } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+});
+
+describe("boolean schema definition subtyping", () => {
+  it("should return true when both schemas are true", () => {
+    const subschema = true as const satisfies SchemaDefinition;
+    const superSchema = true as const satisfies SchemaDefinition;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema is true and superSchema is false", () => {
+    const subschema = true as const satisfies SchemaDefinition;
+    const superSchema = false as const satisfies SchemaDefinition;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should return true when subschema is false (subtype of any schema)", () => {
+    const subschema = false as const satisfies SchemaDefinition;
+    const superSchema = true as const satisfies SchemaDefinition;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return true when subschema is false and superSchema is false", () => {
+    const subschema = false as const satisfies SchemaDefinition;
+    const superSchema = false as const satisfies SchemaDefinition;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+
+  it("should return false when subschema is true and superSchema is an object schema", () => {
+    const subschema = true as const satisfies SchemaDefinition;
+    const superSchema = { type: "string" } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(false);
+  });
+
+  it("should return true when subschema is false and superSchema is an object schema", () => {
+    const subschema = false as const satisfies SchemaDefinition;
+    const superSchema = { type: "string" } as const satisfies Schema;
+    expect(isSubschema(subschema, superSchema)).toBe(true);
+  });
+});

--- a/packages/framework/util/json/src/subschema.ts
+++ b/packages/framework/util/json/src/subschema.ts
@@ -1,0 +1,510 @@
+import { deepEqual } from "@toolcog/util";
+import type { SchemaTypeName, SchemaDefinition, Schema } from "./schema.ts";
+
+const isSubschema = (
+  subschema: SchemaDefinition,
+  superSchema: SchemaDefinition,
+): boolean => {
+  if (typeof subschema === "boolean") {
+    if (typeof superSchema === "boolean") {
+      // `false` is subtype of `false` and `true`.
+      // `true` is subtype of `true` only.
+      return !subschema || superSchema;
+    } else {
+      // `subschema` is a boolean, `superSchema` is an object.
+      // `false` (rejects all values) is a subtype of any schema.
+      // `true` (accepts all values) is only a subtype of `true` schemas.
+      return !subschema;
+    }
+  } else if (typeof superSchema === "boolean") {
+    // `subschema` is an object, `superSchema` is a boolean.
+    // Any schema is subtype of `true`.
+    // No schema is subtype of `false`.
+    return superSchema;
+  }
+
+  if (subschema.$ref !== undefined || superSchema.$ref !== undefined) {
+    throw new Error("$ref is not supported");
+  }
+
+  if (subschema.not !== undefined) {
+    if (superSchema.not !== undefined) {
+      // For `subschema` to be a subtype of `superSchema`,
+      // `superSchema.not` must be a subtype of `subschema.not`.
+      return isSubschema(superSchema.not, subschema.not);
+    } else {
+      // `subschema` rejects certain values that `superSchema` may accept.
+      return true;
+    }
+  }
+
+  if (superSchema.not !== undefined) {
+    // For `subschema` to be a subtype of `superSchema`,
+    // `subschema` must not accept any values that `superSchema` rejects.
+    if (!areDisjoint(subschema, superSchema.not)) {
+      return false;
+    }
+  }
+
+  if (subschema.allOf !== undefined) {
+    // All `subschemas` in `subschema.allOf` must be subtypes of `superSchema`.
+    return subschema.allOf.every((subSubschema) =>
+      isSubschema(subSubschema, superSchema),
+    );
+  }
+
+  if (superSchema.allOf !== undefined) {
+    // `subschema` must be a subtype of all `subschemas` in `superSchema.allOf`.
+    return superSchema.allOf.every((subSuperSchema) =>
+      isSubschema(subschema, subSuperSchema),
+    );
+  }
+
+  if (subschema.anyOf !== undefined) {
+    // Each `subschema` in `subschema.anyOf` must be a subtype of `superSchema`.
+    return subschema.anyOf.every((subSubschema) =>
+      isSubschema(subSubschema, superSchema),
+    );
+  }
+
+  if (superSchema.anyOf !== undefined) {
+    // `subschema` must be a subtype of at least one `subschema`
+    // in `superSchema.anyOf`.
+    return superSchema.anyOf.some((subSuperSchema) =>
+      isSubschema(subschema, subSuperSchema),
+    );
+  }
+
+  if (subschema.oneOf !== undefined) {
+    // Each `subschema` in `subschema.oneOf` must be a subtype of `superSchema`.
+    return subschema.oneOf.every((subSubschema) =>
+      isSubschema(subSubschema, superSchema),
+    );
+  }
+
+  if (superSchema.oneOf !== undefined) {
+    // `subschema` must be a subtype of at least one `subschema`
+    // in `superSchema.oneOf`.
+    return superSchema.oneOf.some((subSuperSchema) =>
+      isSubschema(subschema, subSuperSchema),
+    );
+  }
+
+  if (subschema.type !== undefined && superSchema.type !== undefined) {
+    if (!isTypeSubtype(subschema.type, superSchema.type)) {
+      return false;
+    }
+  } else if (superSchema.type !== undefined) {
+    // `subschema.type` is undefined, but `superSchema.type` is defined;
+    // `subschema` accepts any type, so it cannot be a subtype of a schema
+    // that restricts types.
+    return false;
+  }
+
+  if (subschema.enum !== undefined) {
+    if (superSchema.enum !== undefined) {
+      // All values in `subschema.enum` must be in `superSchema.enum`.
+      if (
+        !subschema.enum.every((valueA) =>
+          superSchema.enum!.some((valueB) => deepEqual(valueA, valueB)),
+        )
+      ) {
+        return false;
+      }
+    } else if (superSchema.const !== undefined) {
+      // All values in `subschema.enum` must equal `superSchema.const`.
+      if (
+        !subschema.enum.every((valueA) => deepEqual(valueA, superSchema.const))
+      ) {
+        return false;
+      }
+    } else {
+      // `subschema.enum` is more restrictive.
+    }
+  }
+
+  if (subschema.const !== undefined) {
+    if (superSchema.const !== undefined) {
+      // All const values must be equal.
+      if (!deepEqual(subschema.const, superSchema.const)) {
+        return false;
+      }
+    } else if (superSchema.enum !== undefined) {
+      // `superSchema.enum` must contain `subschema.const`.
+      if (
+        !superSchema.enum.some((valueB) => deepEqual(subschema.const, valueB))
+      ) {
+        return false;
+      }
+    } else {
+      // `subschema.const` is more restrictive.
+    }
+  }
+
+  if (isNumericType(subschema.type)) {
+    if (!compareNumericConstraints(subschema, superSchema)) {
+      return false;
+    }
+  }
+
+  if (isStringType(subschema.type)) {
+    if (!compareStringConstraints(subschema, superSchema)) {
+      return false;
+    }
+  }
+
+  if (isArrayType(subschema.type)) {
+    if (!compareArrayConstraints(subschema, superSchema)) {
+      return false;
+    }
+  }
+
+  if (isObjectType(subschema.type)) {
+    if (!compareObjectConstraints(subschema, superSchema)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const isTypeSubtype = (
+  subTypes: readonly SchemaTypeName[] | SchemaTypeName,
+  superTypes: readonly SchemaTypeName[] | SchemaTypeName,
+): boolean => {
+  if (!Array.isArray(subTypes)) {
+    subTypes = [subTypes as SchemaTypeName];
+  }
+  if (!Array.isArray(superTypes)) {
+    superTypes = [superTypes as SchemaTypeName];
+  }
+  return subTypes.every((subType) =>
+    superTypes.some(
+      (superType) =>
+        subType === superType ||
+        (subType === "integer" && superType === "number"),
+    ),
+  );
+};
+
+const isNumericType = (
+  type: readonly SchemaTypeName[] | SchemaTypeName | undefined,
+): boolean => {
+  return (
+    type !== undefined &&
+    (type === "integer" ||
+      type === "number" ||
+      (Array.isArray(type) &&
+        type.some((type) => type === "integer" || type === "number")))
+  );
+};
+
+const compareNumericConstraints = (
+  subschema: Schema,
+  superSchema: Schema,
+): boolean => {
+  if (
+    subschema.minimum !== undefined &&
+    (superSchema.minimum === undefined ||
+      subschema.minimum < superSchema.minimum)
+  ) {
+    return false;
+  }
+
+  if (
+    subschema.exclusiveMinimum !== undefined &&
+    (superSchema.exclusiveMinimum === undefined ||
+      subschema.exclusiveMinimum < superSchema.exclusiveMinimum)
+  ) {
+    return false;
+  }
+
+  if (
+    subschema.exclusiveMaximum !== undefined &&
+    (superSchema.exclusiveMaximum === undefined ||
+      subschema.exclusiveMaximum > superSchema.exclusiveMaximum)
+  ) {
+    return false;
+  }
+
+  if (
+    subschema.maximum !== undefined &&
+    (superSchema.maximum === undefined ||
+      subschema.maximum > superSchema.maximum)
+  ) {
+    return false;
+  }
+
+  if (
+    subschema.multipleOf !== undefined &&
+    (superSchema.multipleOf === undefined ||
+      subschema.multipleOf % superSchema.multipleOf !== 0)
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
+const isStringType = (
+  type: readonly SchemaTypeName[] | SchemaTypeName | undefined,
+): boolean => {
+  return (
+    type !== undefined &&
+    (type === "string" || (Array.isArray(type) && type.includes("string")))
+  );
+};
+
+const compareStringConstraints = (
+  subschema: Schema,
+  superSchema: Schema,
+): boolean => {
+  if (subschema.pattern !== undefined) {
+    if (superSchema.pattern === undefined) {
+      // `subschema` is more restrictive.
+    } else {
+      if (subschema.pattern !== superSchema.pattern) {
+        return false;
+      }
+    }
+  }
+
+  if (
+    subschema.minLength !== undefined &&
+    (superSchema.minLength === undefined ||
+      subschema.minLength < superSchema.minLength)
+  ) {
+    return false;
+  }
+
+  if (
+    subschema.maxLength !== undefined &&
+    (superSchema.maxLength === undefined ||
+      subschema.maxLength > superSchema.maxLength)
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
+const isArrayType = (
+  type: readonly SchemaTypeName[] | SchemaTypeName | undefined,
+): boolean => {
+  return (
+    type !== undefined &&
+    (type === "array" || (Array.isArray(type) && type.includes("array")))
+  );
+};
+
+const compareArrayConstraints = (
+  subschema: Schema,
+  superSchema: Schema,
+): boolean => {
+  if (subschema.items !== undefined) {
+    if (superSchema.items === undefined) {
+      // `subschema` is more restrictive.
+    } else {
+      if (Array.isArray(subschema.items) && Array.isArray(superSchema.items)) {
+        if (subschema.items.length !== superSchema.items.length) {
+          return false;
+        }
+        for (let i = 0; i < subschema.items.length; i += 1) {
+          if (
+            !isSubschema(
+              (subschema.items as readonly SchemaDefinition[])[i]!,
+              (superSchema.items as readonly SchemaDefinition[])[i]!,
+            )
+          ) {
+            return false;
+          }
+        }
+      } else if (
+        !Array.isArray(subschema.items) &&
+        !Array.isArray(superSchema.items)
+      ) {
+        if (
+          !isSubschema(
+            subschema.items as SchemaDefinition,
+            superSchema.items as SchemaDefinition,
+          )
+        ) {
+          return false;
+        }
+      } else {
+        // Incompatible items definitions.
+        return false;
+      }
+    }
+  }
+
+  if (subschema.additionalItems !== undefined) {
+    if (superSchema.additionalItems === undefined) {
+      // `superSchema` allows any additional items;
+      // `subschema` may be more restrictive.
+    } else if (superSchema.additionalItems === false) {
+      if (subschema.additionalItems !== false) {
+        // `subschema` allows any additional items, but `superSchema` does not.
+        return false;
+      }
+    } else if (typeof superSchema.additionalItems === "object") {
+      if (subschema.additionalItems === false) {
+        // `subschema` is more restrictive.
+      } else if (typeof subschema.additionalItems === "object") {
+        if (
+          !isSubschema(subschema.additionalItems, superSchema.additionalItems)
+        ) {
+          return false;
+        }
+      } else {
+        // `subschema.additionalItems` is `true` (allows any additional items);
+        // `superSchema.additionalItems` is an object (restricts additional items).
+        return false;
+      }
+    }
+  } else if (superSchema.additionalItems !== undefined) {
+    if (superSchema.additionalItems === false) {
+      // `subschema` allows any additional items;
+      // `superSchema` does not allow additional items.
+      return false;
+    } else if (typeof superSchema.additionalItems === "object") {
+      // `subschema` allows any additional items, but `superSchema` restricts them.
+      return false;
+    }
+  }
+
+  if (subschema.uniqueItems === true && superSchema.uniqueItems !== true) {
+    return false;
+  }
+
+  if (
+    subschema.minItems !== undefined &&
+    (superSchema.minItems === undefined ||
+      subschema.minItems < superSchema.minItems)
+  ) {
+    return false;
+  }
+
+  if (
+    subschema.maxItems !== undefined &&
+    (superSchema.maxItems === undefined ||
+      subschema.maxItems > superSchema.maxItems)
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
+const isObjectType = (
+  type: readonly SchemaTypeName[] | SchemaTypeName | undefined,
+): boolean => {
+  return (
+    type !== undefined &&
+    (type === "object" || (Array.isArray(type) && type.includes("object")))
+  );
+};
+
+const compareObjectConstraints = (
+  subschema: Schema,
+  superSchema: Schema,
+): boolean => {
+  if (superSchema.properties !== undefined) {
+    if (subschema.properties === undefined) {
+      // `subschema` does not define properties that `superSchema` does;
+      // since `subschema` is less restrictive, it cannot be a subtype.
+      return false;
+    } else {
+      for (const key in superSchema.properties) {
+        const superProperty = superSchema.properties[key]!;
+        const subProperty = subschema.properties[key];
+        if (subProperty === undefined) {
+          if (superSchema.required?.includes(key)) {
+            return false; // `subschema` is missing a required property.
+          }
+        } else if (!isSubschema(subProperty, superProperty)) {
+          return false;
+        }
+      }
+    }
+  }
+
+  if (subschema.additionalProperties !== undefined) {
+    if (superSchema.additionalProperties === undefined) {
+      // `superSchema` allows any additional properties;
+      // `subschema` may be more restrictive, so it's a subtype.
+    } else if (superSchema.additionalProperties === false) {
+      if (subschema.additionalProperties !== false) {
+        // `subschema` allows additional properties that `superSchema` does not.
+        return false;
+      }
+    } else if (typeof superSchema.additionalProperties === "object") {
+      if (subschema.additionalProperties === false) {
+        // `subschema` is more restrictive.
+      } else if (typeof subschema.additionalProperties === "object") {
+        if (
+          !isSubschema(
+            subschema.additionalProperties,
+            superSchema.additionalProperties,
+          )
+        ) {
+          return false;
+        }
+      } else {
+        // `subschema` allows any additional properties,
+        // but `superSchema` restricts them, so `subschema` cannot be a subtype.
+        return false;
+      }
+    }
+  } else if (superSchema.additionalProperties !== undefined) {
+    if (
+      superSchema.additionalProperties === false ||
+      typeof superSchema.additionalProperties === "object"
+    ) {
+      // `subschema` allows any additional properties,
+      // but `superSchema` restricts them, so `subschema` cannot be a subtype.
+      return false;
+    }
+  }
+
+  if (superSchema.required !== undefined) {
+    if (subschema.required === undefined) {
+      // `subschema` does not require properties that `superSchema` requires;
+      // `subschema` is less restrictive, so it cannot be a subtype.
+      return false;
+    } else {
+      // All required properties in `superSchema` must be in `subschema`.
+      const missingRequiredProps = superSchema.required.filter(
+        (property) => !subschema.required!.includes(property),
+      );
+      if (missingRequiredProps.length !== 0) {
+        // `subschema` is missing required properties from `superSchema`.
+        return false;
+      }
+    }
+  }
+
+  return true;
+};
+
+const areDisjoint = (
+  subschema: SchemaDefinition,
+  superSchema: SchemaDefinition,
+): boolean => {
+  // Assume schemas are disjoint if they don't have overlapping types.
+  // If there is no intersection between the types, consider them disjoint.
+  const subTypes = getTypes(subschema);
+  const superTypes = getTypes(superSchema);
+  return !subTypes.some((type) => superTypes.includes(type));
+};
+
+const getTypes = (schema: SchemaDefinition): readonly SchemaTypeName[] => {
+  if (typeof schema === "boolean" || schema.type === undefined) {
+    return [];
+  }
+  return Array.isArray(schema.type) ?
+      (schema.type as readonly SchemaTypeName[])
+    : [schema.type as SchemaTypeName];
+};
+
+export { isSubschema };

--- a/packages/framework/util/json/src/validate.test.ts
+++ b/packages/framework/util/json/src/validate.test.ts
@@ -1,0 +1,438 @@
+import { describe, expect, it } from "vitest";
+import type { SchemaTypeName, SchemaDefinition, Schema } from "./schema.ts";
+import { validate } from "./validate.ts";
+
+describe("type validation", () => {
+  it("should validate undefined types", () => {
+    const schema = { type: "undefined" } as const satisfies Schema;
+    expect(validate(undefined, schema)).toBe(true);
+    expect(validate(null, schema)).toBe(false);
+  });
+
+  it("should validate null types", () => {
+    const schema = { type: "null" } as const satisfies Schema;
+    expect(validate(null, schema)).toBe(true);
+    expect(validate("not null", schema)).toBe(false);
+  });
+
+  it("should validate boolean types", () => {
+    const schema = { type: "boolean" } as const satisfies Schema;
+    expect(validate(true, schema)).toBe(true);
+    expect(validate(false, schema)).toBe(true);
+    expect(validate("true", schema)).toBe(false);
+  });
+
+  it("should validate integer types", () => {
+    const schema = { type: "integer" } as const satisfies Schema;
+    expect(validate(5, schema)).toBe(true);
+    expect(validate(-3, schema)).toBe(true);
+    expect(validate(3.14, schema)).toBe(false);
+  });
+
+  it("should validate number types", () => {
+    const schema = { type: "number" } as const satisfies Schema;
+    expect(validate(3.14, schema)).toBe(true);
+    expect(validate(-2.71, schema)).toBe(true);
+    expect(validate("3.14", schema)).toBe(false);
+  });
+
+  it("should validate string types", () => {
+    const schema = { type: "string" } as const satisfies Schema;
+    expect(validate("hello", schema)).toBe(true);
+    expect(validate("", schema)).toBe(true);
+    expect(validate(123, schema)).toBe(false);
+  });
+
+  it("should validate array types", () => {
+    const schema = { type: "array" } as const satisfies Schema;
+    expect(validate([], schema)).toBe(true);
+    expect(validate([1, 2, 3], schema)).toBe(true);
+    expect(validate({}, schema)).toBe(false);
+  });
+
+  it("should validate object types", () => {
+    const schema = { type: "object" } as const satisfies Schema;
+    expect(validate({}, schema)).toBe(true);
+    expect(validate({ key: "value" }, schema)).toBe(true);
+    expect(validate([], schema)).toBe(false);
+  });
+
+  it("should validate multiple types", () => {
+    const schema = { type: ["string", "number"] } as const satisfies Schema;
+    expect(validate("hello", schema)).toBe(true);
+    expect(validate(42, schema)).toBe(true);
+    expect(validate(true, schema)).toBe(false);
+  });
+});
+
+describe("const validation", () => {
+  it("should validate const values", () => {
+    const schema = { const: "fixed value" } as const satisfies Schema;
+    expect(validate("fixed value", schema)).toBe(true);
+    expect(validate("other value", schema)).toBe(false);
+  });
+});
+
+describe("enum validation", () => {
+  it("should validate enum values", () => {
+    const schema = { enum: [1, 2, 3] } as const satisfies Schema;
+    expect(validate(1, schema)).toBe(true);
+    expect(validate(4, schema)).toBe(false);
+  });
+});
+
+describe("number validation", () => {
+  it("should validate minimum constraints", () => {
+    const schema = { type: "number", minimum: 5 } as const satisfies Schema;
+    expect(validate(5, schema)).toBe(true);
+    expect(validate(4.99, schema)).toBe(false);
+  });
+
+  it("should validate exclusiveMinimum constraints", () => {
+    const schema = {
+      type: "number",
+      exclusiveMinimum: 5,
+    } as const satisfies Schema;
+    expect(validate(5.01, schema)).toBe(true);
+    expect(validate(5, schema)).toBe(false);
+  });
+
+  it("should validate exclusiveMaximum constraints", () => {
+    const schema = {
+      type: "number",
+      exclusiveMaximum: 10,
+    } as const satisfies Schema;
+    expect(validate(9.99, schema)).toBe(true);
+    expect(validate(10, schema)).toBe(false);
+  });
+
+  it("should validate maximum constraints", () => {
+    const schema = { type: "number", maximum: 10 } as const satisfies Schema;
+    expect(validate(10, schema)).toBe(true);
+    expect(validate(11, schema)).toBe(false);
+  });
+
+  it("should validate multipleOf constraints", () => {
+    const schema = {
+      type: "number",
+      multipleOf: 2,
+    } as const satisfies Schema;
+    expect(validate(4, schema)).toBe(true);
+    expect(validate(5, schema)).toBe(false);
+  });
+});
+
+describe("string validation", () => {
+  it("should validate minLength constraints", () => {
+    const schema = {
+      type: "string",
+      minLength: 3,
+    } as const satisfies Schema;
+    expect(validate("hi", schema)).toBe(false);
+    expect(validate("hello", schema)).toBe(true);
+  });
+
+  it("should validate maxLength constraints", () => {
+    const schema = { type: "string", maxLength: 5 } as const satisfies Schema;
+    expect(validate("hello", schema)).toBe(true);
+    expect(validate("hello!", schema)).toBe(false);
+  });
+
+  it("should validate pattern constraints", () => {
+    const schema = {
+      type: "string",
+      pattern: "^a.*z$",
+    } as const satisfies Schema;
+    expect(validate("abcz", schema)).toBe(true);
+    expect(validate("abz", schema)).toBe(true);
+    expect(validate("abczx", schema)).toBe(false); // Does not end with 'z'
+    expect(validate("baz", schema)).toBe(false); // Does not start with 'a'
+  });
+});
+
+describe("array validation", () => {
+  it("should validate items constraints", () => {
+    const schema = {
+      type: "array",
+      items: { type: "number" },
+    } as const satisfies Schema;
+    expect(validate([1, 2, 3], schema)).toBe(true);
+    expect(validate([1, "2", 3], schema)).toBe(false);
+  });
+
+  it("should validate tuple items constraints", () => {
+    const schema = {
+      type: "array",
+      items: [{ type: "number" }, { type: "string" }],
+      additionalItems: false,
+    } as const satisfies Schema;
+    expect(validate([1, "two"], schema)).toBe(true);
+    expect(validate([1, "two", 3], schema)).toBe(false);
+  });
+
+  it("should validate uniqueItem constraints", () => {
+    const schema = {
+      type: "array",
+      uniqueItems: true,
+    } as const satisfies Schema;
+    expect(validate([1, 2, 3], schema)).toBe(true);
+    expect(validate([1, 2, 1], schema)).toBe(false);
+  });
+
+  it("should validate contains constraints", () => {
+    const schema = {
+      type: "array",
+      contains: { type: "number", minimum: 5 },
+    } as const satisfies Schema;
+    expect(validate([1, 2, 5], schema)).toBe(true);
+    expect(validate([1, 2, 3], schema)).toBe(false);
+  });
+
+  it("should validate minItems constraints", () => {
+    const schema = {
+      type: "array",
+      minItems: 2,
+    } as const satisfies Schema;
+    expect(validate([1], schema)).toBe(false);
+    expect(validate([1, 2], schema)).toBe(true);
+  });
+
+  it("should validate maxItems constraints", () => {
+    const schema = { type: "array", maxItems: 3 } as const satisfies Schema;
+    expect(validate([1, 2, 3], schema)).toBe(true);
+    expect(validate([1, 2, 3, 4], schema)).toBe(false);
+  });
+});
+
+describe("object validation", () => {
+  it("should validate properties constraints", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        age: { type: "integer" },
+      },
+    } as const satisfies Schema;
+    expect(validate({ name: "Alice", age: 30 }, schema)).toBe(true);
+    expect(validate({ name: "Bob", age: "30" }, schema)).toBe(false);
+  });
+
+  it("should validate additionalProperties constraints", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+      additionalProperties: false,
+    } as const satisfies Schema;
+    expect(validate({ name: "Charlie" }, schema)).toBe(true);
+    expect(validate({ name: "Dave", age: 40 }, schema)).toBe(false);
+  });
+
+  it("should validate patternProperties constraints", () => {
+    const schema = {
+      type: "object",
+      patternProperties: {
+        "^S_": { type: "string" },
+        "^I_": { type: "integer" },
+      },
+    } as const satisfies Schema;
+    expect(
+      validate({ S_name: "Eve", I_age: 25, S_city: "Wonderland" }, schema),
+    ).toBe(true);
+    expect(validate({ S_name: "Eve", I_age: "25" }, schema)).toBe(false);
+  });
+
+  it("should validate required properties constraints", () => {
+    const schema = {
+      type: "object",
+      required: ["a", "b"],
+    } as const satisfies Schema;
+    expect(validate({ a: 1, b: 2 }, schema)).toBe(true);
+    expect(validate({ a: 1 }, schema)).toBe(false);
+  });
+
+  it("should validate minProperties constraints", () => {
+    const schema = {
+      type: "object",
+      minProperties: 1,
+    } as const satisfies Schema;
+    expect(validate({}, schema)).toBe(false);
+    expect(validate({ a: 1 }, schema)).toBe(true);
+  });
+
+  it("should validate maxProperties constraints", () => {
+    const schema = {
+      type: "object",
+      maxProperties: 2,
+    } as const satisfies Schema;
+    expect(validate({ a: 1, b: 2 }, schema)).toBe(true);
+    expect(validate({ a: 1, b: 2, c: 3 }, schema)).toBe(false);
+  });
+});
+
+describe("logical validation", () => {
+  it("should validate allOf operators", () => {
+    const schema = {
+      allOf: [{ type: "number" }, { minimum: 10 }, { maximum: 20 }],
+    } as const satisfies Schema;
+    expect(validate(15, schema)).toBe(true);
+    expect(validate(25, schema)).toBe(false);
+  });
+
+  it("should validate anyOf operators", () => {
+    const schema = {
+      anyOf: [{ type: "string" }, { type: "number" }],
+    } as const satisfies Schema;
+    expect(validate("hello", schema)).toBe(true);
+    expect(validate(42, schema)).toBe(true);
+    expect(validate(true, schema)).toBe(false);
+  });
+
+  it("should validate oneOf operators", () => {
+    const schema = {
+      oneOf: [{ type: "number" }, { type: "integer" }],
+    } as const satisfies Schema;
+    expect(validate(3.14, schema)).toBe(true);
+    expect(validate(5, schema)).toBe(false);
+  });
+
+  it("should validate not operators", () => {
+    const schema = { not: { type: "string" } } as const satisfies Schema;
+    expect(validate(123, schema)).toBe(true);
+    expect(validate("not allowed", schema)).toBe(false);
+  });
+
+  it("should validate if-then-else operators", () => {
+    const schema = {
+      if: { type: "number" },
+      then: { minimum: 0 },
+      else: { type: "string" },
+    } as const satisfies Schema;
+    expect(validate(5, schema)).toBe(true);
+    expect(validate(-3, schema)).toBe(false);
+    expect(validate("hello", schema)).toBe(true);
+    expect(validate(true, schema)).toBe(false);
+  });
+});
+
+describe("complex schema validation", () => {
+  it("should validate a complex user schema", () => {
+    const userSchema = {
+      type: "object",
+      required: ["id", "name", "email"],
+      properties: {
+        id: { type: "integer" },
+        name: { type: "string" },
+        email: { type: "string", format: "email" },
+        roles: {
+          type: "array",
+          items: { type: "string" },
+          minItems: 1,
+        },
+        metadata: {
+          type: "object",
+          additionalProperties: { type: "string" },
+        },
+      },
+      additionalProperties: false,
+    } as const satisfies Schema;
+
+    const validUser = {
+      id: 1,
+      name: "Alice",
+      email: "alice@example.com",
+      roles: ["admin", "user"],
+      metadata: { department: "IT" },
+    };
+
+    const invalidUser = {
+      id: "1", // Invalid id type.
+      name: "Bob",
+      email: "bob@example.com",
+      roles: [],
+    };
+
+    expect(validate(validUser, userSchema)).toBe(true);
+    expect(validate(invalidUser, userSchema)).toBe(false);
+  });
+
+  it("should validate nested objects and arrays", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        users: {
+          type: "array",
+          items: {
+            type: "object",
+            required: ["username", "preferences"],
+            properties: {
+              username: { type: "string" },
+              preferences: {
+                type: "object",
+                properties: {
+                  notifications: { type: "boolean" },
+                  theme: { type: "string" },
+                },
+                required: ["notifications"],
+              },
+            },
+          },
+        },
+      },
+    } as const satisfies Schema;
+
+    const validData = {
+      users: [
+        {
+          username: "user1",
+          preferences: { notifications: true, theme: "dark" },
+        },
+        {
+          username: "user2",
+          preferences: { notifications: false },
+        },
+      ],
+    };
+
+    const invalidData = {
+      users: [
+        {
+          username: "user1",
+          preferences: { theme: "light" },
+        },
+      ],
+    };
+
+    expect(validate(validData, schema)).toBe(true);
+    expect(validate(invalidData, schema)).toBe(false);
+  });
+});
+
+describe("edge cases", () => {
+  it("should handle empty schemas (accept anything)", () => {
+    const schema = {} as const satisfies Schema;
+    expect(validate(null, schema)).toBe(true);
+    expect(validate(123, schema)).toBe(true);
+    expect(validate("string", schema)).toBe(true);
+  });
+
+  it("should handle `true` schemas (accept anything)", () => {
+    const schema = true as const satisfies SchemaDefinition;
+    expect(validate(null, schema)).toBe(true);
+    expect(validate(123, schema)).toBe(true);
+  });
+
+  it("should handle `false` schemas (reject everything)", () => {
+    const schema = false as const satisfies SchemaDefinition;
+    expect(validate(null, schema)).toBe(false);
+    expect(validate(123, schema)).toBe(false);
+  });
+
+  it("should reject invalid types in type validation", () => {
+    const schema = {
+      type: "unknown" as SchemaTypeName,
+    } as const satisfies Schema;
+    expect(validate(123, schema)).toBe(false);
+  });
+});

--- a/packages/framework/util/json/src/validate.ts
+++ b/packages/framework/util/json/src/validate.ts
@@ -1,0 +1,412 @@
+import { deepEqual } from "@toolcog/util";
+import type {
+  SchemaTypeName,
+  SchemaType,
+  SchemaDefinition,
+  Schema,
+} from "./schema.ts";
+
+const validate = (value: unknown, schema: SchemaDefinition): boolean => {
+  if (typeof schema === "boolean") {
+    return schema;
+  }
+
+  if (schema.$ref !== undefined) {
+    throw new Error("$ref is not supported");
+  }
+
+  if (schema.type !== undefined) {
+    if (!validateType(value, schema.type)) {
+      return false;
+    }
+  }
+
+  if (schema.enum !== undefined) {
+    if (!validateEnum(value, schema.enum)) {
+      return false;
+    }
+  }
+
+  if (schema.const !== undefined) {
+    if (!validateConst(value, schema.const)) {
+      return false;
+    }
+  }
+
+  if (
+    schema.minimum !== undefined ||
+    schema.exclusiveMaximum !== undefined ||
+    schema.exclusiveMinimum !== undefined ||
+    schema.maximum !== undefined ||
+    schema.multipleOf !== undefined
+  ) {
+    if (!validateNumber(value, schema)) {
+      return false;
+    }
+  }
+
+  if (
+    schema.pattern !== undefined ||
+    schema.minLength !== undefined ||
+    schema.maxLength !== undefined
+  ) {
+    if (!validateString(value, schema)) {
+      return false;
+    }
+  }
+
+  if (
+    schema.items !== undefined ||
+    schema.additionalItems !== undefined ||
+    schema.uniqueItems !== undefined ||
+    schema.contains !== undefined ||
+    schema.minItems !== undefined ||
+    schema.maxItems !== undefined
+  ) {
+    if (!validateArray(value, schema)) {
+      return false;
+    }
+  }
+
+  if (
+    schema.properties !== undefined ||
+    schema.additionalProperties !== undefined ||
+    schema.patternProperties !== undefined ||
+    schema.required !== undefined ||
+    schema.minProperties !== undefined ||
+    schema.maxProperties !== undefined
+  ) {
+    if (!validateObject(value, schema)) {
+      return false;
+    }
+  }
+
+  if (schema.allOf !== undefined) {
+    for (const subschema of schema.allOf) {
+      if (!validate(value, subschema)) {
+        return false;
+      }
+    }
+  }
+
+  if (schema.anyOf !== undefined) {
+    let valid = false;
+    for (const subschema of schema.anyOf) {
+      if (validate(value, subschema)) {
+        valid = true;
+        break;
+      }
+    }
+    if (!valid) {
+      return false;
+    }
+  }
+
+  if (schema.oneOf !== undefined) {
+    let validCount = 0;
+    for (const subschema of schema.oneOf) {
+      if (validate(value, subschema)) {
+        validCount += 1;
+      }
+    }
+    if (validCount !== 1) {
+      return false;
+    }
+  }
+
+  if (schema.not !== undefined) {
+    if (validate(value, schema.not)) {
+      return false;
+    }
+  }
+
+  if (schema.if !== undefined) {
+    if (validate(value, schema.if)) {
+      if (schema.then !== undefined && !validate(value, schema.then)) {
+        return false;
+      }
+    } else {
+      if (schema.else !== undefined && !validate(value, schema.else)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+};
+
+const validateType = (
+  value: unknown,
+  schemaType: readonly SchemaTypeName[] | SchemaTypeName,
+): boolean => {
+  const types =
+    Array.isArray(schemaType) ?
+      (schemaType as readonly SchemaTypeName[])
+    : [schemaType as SchemaTypeName];
+
+  for (const type of types) {
+    if (typeMatches(value, type)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const typeMatches = (value: unknown, type: SchemaTypeName): boolean => {
+  switch (type) {
+    case "void":
+      return value === undefined;
+    case "undefined":
+      return typeof value === "undefined";
+    case "null":
+      return value === null;
+    case "boolean":
+      return typeof value === "boolean";
+    case "integer":
+      return Number.isInteger(value);
+    case "number":
+      return typeof value === "number" && !isNaN(value);
+    case "string":
+      return typeof value === "string";
+    case "array":
+      return Array.isArray(value);
+    case "object":
+      return (
+        typeof value === "object" && value !== null && !Array.isArray(value)
+      );
+    default:
+      return false;
+  }
+};
+
+const validateEnum = (
+  value: unknown,
+  enumValues: readonly SchemaType[],
+): boolean => {
+  for (const enumValue of enumValues) {
+    if (deepEqual(value, enumValue)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const validateConst = (value: unknown, constValue: SchemaType): boolean => {
+  return deepEqual(value, constValue);
+};
+
+const validateNumber = (value: unknown, schema: Schema): boolean => {
+  if (typeof value !== "number" || isNaN(value)) {
+    return false;
+  }
+
+  if (schema.minimum !== undefined) {
+    if (value < schema.minimum) {
+      return false;
+    }
+  }
+
+  if (schema.exclusiveMinimum !== undefined) {
+    if (value <= schema.exclusiveMinimum) {
+      return false;
+    }
+  }
+
+  if (schema.exclusiveMaximum !== undefined) {
+    if (value >= schema.exclusiveMaximum) {
+      return false;
+    }
+  }
+
+  if (schema.maximum !== undefined) {
+    if (value > schema.maximum) {
+      return false;
+    }
+  }
+
+  if (schema.multipleOf !== undefined) {
+    if ((value / schema.multipleOf) % 1 !== 0) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const validateString = (value: unknown, schema: Schema): boolean => {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  if (schema.pattern !== undefined) {
+    const regex = new RegExp(schema.pattern);
+    if (!regex.test(value)) {
+      return false;
+    }
+  }
+
+  if (schema.minLength !== undefined) {
+    if (value.length < schema.minLength) {
+      return false;
+    }
+  }
+
+  if (schema.maxLength !== undefined) {
+    if (value.length > schema.maxLength) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const validateArray = (value: unknown, schema: Schema): boolean => {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+
+  if (schema.items !== undefined) {
+    if (Array.isArray(schema.items)) {
+      for (let i = 0; i < schema.items.length; i += 1) {
+        const itemSchema = (schema.items as readonly SchemaDefinition[])[i]!;
+        const itemValue = (value as unknown[])[i];
+        if (!validate(itemValue, itemSchema)) {
+          return false;
+        }
+      }
+      if (schema.additionalItems !== undefined) {
+        if (schema.additionalItems === false) {
+          if (value.length > schema.items.length) {
+            return false;
+          }
+        } else {
+          const additionalSchema = schema.additionalItems;
+          for (let i = schema.items.length; i < value.length; i += 1) {
+            if (!validate(value[i], additionalSchema)) {
+              return false;
+            }
+          }
+        }
+      }
+    } else {
+      const itemSchema = schema.items as SchemaDefinition;
+      for (const item of value) {
+        if (!validate(item, itemSchema)) {
+          return false;
+        }
+      }
+    }
+  }
+
+  if (schema.uniqueItems) {
+    const uniqueItems = new Set();
+    for (const item of value) {
+      const itemKey = JSON.stringify(item);
+      if (uniqueItems.has(itemKey)) {
+        return false;
+      }
+      uniqueItems.add(itemKey);
+    }
+  }
+
+  if (schema.contains !== undefined) {
+    const containsSchema = schema.contains;
+    let containsValid = false;
+    for (const item of value) {
+      if (validate(item, containsSchema)) {
+        containsValid = true;
+        break;
+      }
+    }
+    if (!containsValid) {
+      return false;
+    }
+  }
+
+  if (schema.minItems !== undefined) {
+    if (value.length < schema.minItems) {
+      return false;
+    }
+  }
+
+  if (schema.maxItems !== undefined) {
+    if (value.length > schema.maxItems) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const validateObject = (value: unknown, schema: Schema): boolean => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const keys = Object.keys(value);
+
+  const propertyValidators: { [key: string]: SchemaDefinition } = {};
+  if (schema.properties !== undefined) {
+    Object.assign(propertyValidators, schema.properties);
+  }
+
+  const additionalProperties = schema.additionalProperties ?? true;
+
+  if (schema.patternProperties !== undefined) {
+    for (const pattern in schema.patternProperties) {
+      const regex = new RegExp(pattern);
+      for (const key of keys) {
+        if (regex.test(key)) {
+          propertyValidators[key] = schema.patternProperties[pattern]!;
+        }
+      }
+    }
+  }
+
+  for (const key of keys) {
+    const propertySchema = propertyValidators[key];
+    if (propertySchema !== undefined) {
+      if (
+        !validate((value as Record<PropertyKey, unknown>)[key], propertySchema)
+      ) {
+        return false;
+      }
+    } else if (additionalProperties === false) {
+      return false;
+    } else if (typeof additionalProperties === "object") {
+      if (
+        !validate(
+          (value as Record<PropertyKey, unknown>)[key],
+          additionalProperties,
+        )
+      ) {
+        return false;
+      }
+    }
+  }
+
+  if (schema.required !== undefined) {
+    for (const requiredKey of schema.required) {
+      if (!Object.prototype.hasOwnProperty.call(value, requiredKey)) {
+        return false;
+      }
+    }
+  }
+
+  if (schema.minProperties !== undefined) {
+    if (keys.length < schema.minProperties) {
+      return false;
+    }
+  }
+
+  if (schema.maxProperties !== undefined) {
+    if (keys.length > schema.maxProperties) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+export { validate };

--- a/packages/framework/util/src/equal.ts
+++ b/packages/framework/util/src/equal.ts
@@ -1,0 +1,40 @@
+const deepEqual = (a: unknown, b: unknown): boolean => {
+  if (a === b) {
+    return true;
+  } else if (typeof a !== typeof b) {
+    return false;
+  } else if (typeof a !== "object" || a === null || b === null) {
+    return false;
+  }
+
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) {
+      return false;
+    }
+    for (let i = 0; i < a.length; i += 1) {
+      if (!deepEqual(a[i], b[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b as object);
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  for (const key of aKeys) {
+    if (
+      !deepEqual(
+        (a as Record<PropertyKey, unknown>)[key],
+        (b as Record<PropertyKey, unknown>)[key],
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
+};
+
+export { deepEqual };

--- a/packages/framework/util/src/lib.ts
+++ b/packages/framework/util/src/lib.ts
@@ -1,3 +1,5 @@
+export { deepEqual } from "./equal.ts";
+
 export {
   countLines,
   reduceLines,


### PR DESCRIPTION
The `validate` function checks if a given value conforms to a schema object. The `isSubschema` function checks if one subschema represents a subtype of another schema. The `matchSchema` function returns the most specific subschema that matches a given value. When multiple subschemas match.

The `formatJson` function now uses `matchSchema` internally to splice in descriptive comments for a polymorphic value's most specific subtype.