### PR TITLE
Generate additional schema metadata

### DIFF
--- a/.changeset/fifty-years-nail.md
+++ b/.changeset/fifty-years-nail.md
@@ -1,0 +1,9 @@
+---
+"@toolcog/compiler": patch
+---
+
+Generate additional schema metadata
+
+Set "title" fields in generated schemas to type names, when available.
+Set "default" fields in generated schemas to the value of `@default` doc tags.
+Set const schema variant descriptions from `@constant` doc tags of parent type.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,7 +12,7 @@ export default pluginTs.config(
       "jsdoc/check-line-alignment": "error",
       "jsdoc/check-tag-names": [
         "error",
-        { definedTags: ["id", "idiom", "instructions", "noid"] },
+        { definedTags: ["constant", "id", "idiom", "instructions", "noid"] },
       ],
       "jsdoc/no-bad-blocks": "error",
       "jsdoc/require-jsdoc": "off",

--- a/packages/framework/compiler/src/comment.ts
+++ b/packages/framework/compiler/src/comment.ts
@@ -7,6 +7,7 @@ interface Comment {
   params: Record<string, string>;
   returns: string | undefined;
   idioms: string[];
+  constants: Record<string, string>;
   tags: Record<string, string>;
 }
 
@@ -113,6 +114,12 @@ const parseTag = (
     return;
   }
 
+  if (tag === "constant") {
+    const [, name, description] = parseTypedValue(ts, value, { named: true });
+    comment.constants[name] = description;
+    return;
+  }
+
   comment.tags[tag] = value;
 };
 
@@ -125,6 +132,7 @@ const parseComment = (
     params: Object.create(null) as Record<string, string>,
     returns: undefined,
     idioms: [],
+    constants: Object.create(null) as Record<string, string>,
     tags: Object.create(null) as Record<string, string>,
   };
 
@@ -170,6 +178,7 @@ const mergeComments: {
   const params = Object.create(null) as Record<string, string>;
   let returns: string | undefined;
   const idioms = new Set<string>();
+  const constants = Object.create(null) as Record<string, string>;
   const tags = Object.create(null) as Record<string, string>;
 
   for (const comment of comments) {
@@ -190,6 +199,9 @@ const mergeComments: {
     for (const idiom of comment.idioms) {
       idioms.add(idiom);
     }
+    for (const constant in comment.constants) {
+      constants[constant] = comment.constants[constant]!;
+    }
     for (const tag in comment.tags) {
       tags[tag] = comment.tags[tag]!;
     }
@@ -204,6 +216,7 @@ const mergeComments: {
     params,
     returns,
     idioms: [...idioms],
+    constants,
     tags,
   };
 }) as typeof mergeComments;

--- a/packages/framework/compiler/src/transformer.ts
+++ b/packages/framework/compiler/src/transformer.ts
@@ -480,15 +480,22 @@ const transformToolcog = (
       }
 
       // Remove intrinsic imports.
-      return removeImportsWithTypes(ts, factory, checker, node, [
-        intrinsicTypes.defineIdiom,
-        intrinsicTypes.defineIdioms,
-        intrinsicTypes.defineIndex,
-        intrinsicTypes.defineTool,
-        intrinsicTypes.defineTools,
-        intrinsicTypes.defineFunction,
-        intrinsicTypes.prompt,
-      ]);
+      return removeImportsWithTypes(
+        ts,
+        factory,
+        checker,
+        node,
+        [
+          intrinsicTypes.defineIdiom,
+          intrinsicTypes.defineIdioms,
+          intrinsicTypes.defineIndex,
+          intrinsicTypes.defineTool,
+          intrinsicTypes.defineTools,
+          intrinsicTypes.defineFunction,
+          intrinsicTypes.prompt,
+        ],
+        "@toolcog/core",
+      );
     };
     sourceFile = ts.visitEachChild(sourceFile, postprocessNode, context);
 

--- a/packages/framework/compiler/src/utils/imports.ts
+++ b/packages/framework/compiler/src/utils/imports.ts
@@ -67,7 +67,16 @@ const removeImportsWithTypes = (
   checker: ts.TypeChecker,
   importDeclaration: ts.ImportDeclaration,
   importTypes: readonly (ts.Type | undefined)[],
+  moduleSpecifier?: string,
 ): ts.ImportDeclaration | undefined => {
+  if (
+    moduleSpecifier !== undefined &&
+    ts.isStringLiteral(importDeclaration.moduleSpecifier) &&
+    moduleSpecifier !== importDeclaration.moduleSpecifier.text
+  ) {
+    return importDeclaration;
+  }
+
   let importClause = importDeclaration.importClause;
   if (importClause === undefined) {
     return importDeclaration;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -504,6 +504,9 @@ importers:
       '@toolcog/util':
         specifier: workspace:*
         version: link:../packages/framework/util
+      toolcog:
+        specifier: workspace:*
+        version: link:../packages/toolcog
     optionalDependencies:
       '@toolcog/anthropic':
         specifier: workspace:*

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -12,7 +12,8 @@
     "@toolcog/compiler": "workspace:*",
     "@toolcog/core": "workspace:*",
     "@toolcog/runtime": "workspace:*",
-    "@toolcog/util": "workspace:*"
+    "@toolcog/util": "workspace:*",
+    "toolcog": "workspace:*"
   },
   "optionalDependencies": {
     "@toolcog/anthropic": "workspace:*",


### PR DESCRIPTION
Set "title" fields in generated schemas to type names, when available. Set "default" fields in generated schemas to the value of `@default` doc tags. Set const schema variant descriptions from `@constant` doc tags of parent type.

Only attempt to remove unused intrinsic imports when imported from the `@toolcog/core` package.