### PR TITLE
fix: Don't wrap markdown headings when formatting REPL output

### DIFF
--- a/.changeset/tiny-lemons-sort.md
+++ b/.changeset/tiny-lemons-sort.md
@@ -1,0 +1,5 @@
+---
+"@toolcog/repl": patch
+---
+
+Don't wrap markdown headings when formatting REPL output.

--- a/packages/framework/repl/src/markdown.ts
+++ b/packages/framework/repl/src/markdown.ts
@@ -212,10 +212,7 @@ const renderMarkdownHeading = (
   }
   const text = renderMarkdownInline(token.tokens, theme);
   const indent = " ".repeat(depth);
-  return replaceLines(
-    wrapText(reflow(text), width - indent.length),
-    (line) => indent + heading(line),
-  );
+  return indent + heading(text);
 };
 
 const renderMarkdownHr = (


### PR DESCRIPTION
Markdown headings can't contain line breaks.