### PR TITLE
feat: Add toolkit+inventory loader and ephemeral package installer

### DIFF
--- a/.changeset/wild-knives-drum.md
+++ b/.changeset/wild-knives-drum.md
@@ -1,0 +1,26 @@
+---
+"@toolcog/runtime": patch
+"@toolcog/core": patch
+"@toolcog/node": patch
+---
+
+Add toolkit+inventory loader and ephemeral package installer.
+
+Toolkits can now be loaded with `--toolkit <module>`. Multiple toolkits
+can be loaded by specifying multiple `--toolkit` options.
+Plugins can now be loaded with `--plugin <module>`. Multiple plugins
+can be loaded by specifying multiple `--plugin` options.
+
+Similar to `npx`, if a toolkit or plugin module represents a package import
+that fails to resolve, the CLI will offer to install the missing packages.
+If permitted to do so, the missing packages will be installed in
+`~/.toolcog/packages/<hash>`, where `<hash>` is a hash of the to-be-installed
+package names. The requested modules will then be loaded from the ephemeral
+installation directory.
+
+Loading a toolkit with `--toolkit` also attempts to load a corresponding
+inventory module by appending "/toolcog-inventory" to the module name,
+if the module represents a package import.
+
+All loaded plugins, toolkits, and inventories are registered with the
+current runtime.

--- a/packages/adapters/node/installer/package.json
+++ b/packages/adapters/node/installer/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@toolcog/node/installer",
+  "type": "module"
+}

--- a/packages/adapters/node/installer/src/install.ts
+++ b/packages/adapters/node/installer/src/install.ts
@@ -1,0 +1,197 @@
+import { exec } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import {
+  isAbsolute as isAbsolutePath,
+  resolve as resolvePath,
+} from "node:path";
+import { promisify } from "node:util";
+import ts from "typescript";
+import { style, confirm } from "@toolcog/util/tui";
+
+const execAsync = promisify(exec);
+
+/** @internal */
+const isPackageImport = (moduleName: string): boolean => {
+  return !moduleName.startsWith(".") && !isAbsolutePath(moduleName);
+};
+
+/** @internal */
+const getPackageName = (moduleName: string): string => {
+  const parts = moduleName.split("/");
+  if (moduleName.startsWith("@")) {
+    return parts.slice(0, 2).join("/");
+  } else {
+    return parts[0]!;
+  }
+};
+
+interface LoadModulesOptions {
+  searchDirs?: string[] | undefined;
+}
+
+interface InstallPackagesOptions extends LoadModulesOptions {
+  message?: string | undefined;
+  confirm?: string | boolean | undefined;
+}
+
+const loadModules = async (
+  modules: readonly string[],
+  options?: LoadModulesOptions,
+): Promise<{
+  loadedModules: Record<string, unknown>;
+  missingModules: string[];
+}> => {
+  const containingFiles = (options?.searchDirs ?? [process.cwd()]).map(
+    (searchDir) => resolvePath(searchDir, "package.json"),
+  );
+  const compilerOptions: ts.CompilerOptions = {
+    allowImportingTsExtensions: true,
+    module: ts.ModuleKind.NodeNext,
+    noDtsResolution: true,
+    target: ts.ScriptTarget.ESNext,
+  };
+
+  const loadedModules = Object.create(null) as Record<string, unknown>;
+  const missingModules: string[] = [];
+
+  for (const moduleName of modules) {
+    for (const containingFile of containingFiles) {
+      const resolvedModule = ts.resolveModuleName(
+        moduleName,
+        containingFile,
+        compilerOptions,
+        ts.sys,
+        undefined,
+        undefined,
+        ts.ModuleKind.ESNext,
+      ).resolvedModule;
+      if (resolvedModule !== undefined) {
+        const modulePath = resolvedModule.resolvedFileName;
+        const module = (await import(modulePath)) as unknown;
+        loadedModules[moduleName] = module;
+        break;
+      } else {
+        loadedModules[moduleName] = null;
+        if (isPackageImport(moduleName)) {
+          missingModules.push(moduleName);
+        }
+      }
+    }
+  }
+
+  return { loadedModules, missingModules };
+};
+
+/**
+ * Installs the specified packages into a temporary directory and returns
+ * the path to the temporary package directory.
+ */
+const installPackages = async (
+  packages: readonly string[],
+  options?: InstallPackagesOptions,
+): Promise<string> => {
+  const hash = createHash("sha256")
+    .update(packages.join(","))
+    .digest("hex")
+    .substring(0, 16);
+
+  const installDir = resolvePath(homedir(), ".toolcog", "packages", hash);
+  if (!existsSync(installDir)) {
+    if (options?.confirm === undefined || options.confirm !== false) {
+      console.log(
+        style.bold(
+          options?.message ?? "Need to install the following packages:",
+        ) +
+          "\n" +
+          packages
+            .map((packageName) => "- " + style.green(packageName))
+            .join("\n"),
+      );
+      const proceed = await confirm({
+        message:
+          typeof options?.confirm === "string" ?
+            options.confirm
+          : "Ok to install?",
+      });
+      if (!proceed) {
+        process.exit(1);
+      }
+    }
+
+    await mkdir(installDir, { recursive: true });
+  }
+
+  try {
+    await execAsync("npm install " + packages.join(" "), { cwd: installDir });
+  } catch (error) {
+    throw new Error(
+      "Failed to install packages " +
+        packages.join(", ") +
+        ": " +
+        ((error as { stderr?: string }).stderr ?? (error as Error).message),
+    );
+  }
+
+  return installDir;
+};
+
+const loadOrInstallModules = async (
+  modules: readonly string[],
+  options?: InstallPackagesOptions,
+): Promise<{
+  loadedModules: Record<string, unknown>;
+  installDir: string | undefined;
+}> => {
+  const { loadedModules, missingModules } = await loadModules(modules, options);
+
+  let installDir: string | undefined;
+  if (missingModules.length !== 0) {
+    const packages = new Set<string>();
+    for (const moduleName of missingModules) {
+      packages.add(getPackageName(moduleName));
+    }
+
+    installDir = await installPackages([...packages], options);
+
+    const containingFile = resolvePath(installDir, "package.json");
+    const compilerOptions: ts.CompilerOptions = {
+      allowImportingTsExtensions: true,
+      module: ts.ModuleKind.NodeNext,
+      noDtsResolution: true,
+      target: ts.ScriptTarget.ESNext,
+    };
+
+    for (const moduleName of missingModules) {
+      const resolvedModule = ts.resolveModuleName(
+        moduleName,
+        containingFile,
+        compilerOptions,
+        ts.sys,
+        undefined,
+        undefined,
+        ts.ModuleKind.ESNext,
+      ).resolvedModule;
+      if (resolvedModule !== undefined) {
+        const modulePath = resolvedModule.resolvedFileName;
+        const module = (await import(modulePath)) as unknown;
+        loadedModules[moduleName] = module;
+      } else {
+        loadedModules[moduleName] = null;
+      }
+    }
+  }
+
+  return { loadedModules, installDir };
+};
+
+export type { LoadModulesOptions, InstallPackagesOptions };
+export {
+  isPackageImport,
+  getPackageName,
+  loadModules,
+  installPackages,
+  loadOrInstallModules,
+};

--- a/packages/adapters/node/installer/src/mod.ts
+++ b/packages/adapters/node/installer/src/mod.ts
@@ -1,0 +1,8 @@
+export type { LoadModulesOptions, InstallPackagesOptions } from "./install.ts";
+export {
+  isPackageImport,
+  getPackageName,
+  loadModules,
+  installPackages,
+  loadOrInstallModules,
+} from "./install.ts";

--- a/packages/adapters/node/installer/tsconfig.json
+++ b/packages/adapters/node/installer/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../../tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "types": ["node", "ts-expose-internals"]
+  }
+}

--- a/packages/adapters/node/installer/typedoc.json
+++ b/packages/adapters/node/installer/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "extends": ["../../../../typedoc.base.json"],
+  "entryPoints": ["src/mod.ts"]
+}

--- a/packages/adapters/node/package.json
+++ b/packages/adapters/node/package.json
@@ -58,6 +58,11 @@
       "types": "./dist/register.d.ts",
       "import": "./dist/register.js",
       "require": "./dist/register.cjs"
+    },
+    "./installer": {
+      "types": "./dist/installer.d.ts",
+      "import": "./dist/installer.js",
+      "require": "./dist/installer.cjs"
     }
   },
   "peerDependencies": {
@@ -68,6 +73,7 @@
     "@toolcog/core": "workspace:*",
     "@toolcog/repl": "workspace:*",
     "@toolcog/runtime": "workspace:*",
+    "@toolcog/util": "workspace:*",
     "@types/node": "catalog:default",
     "commander": "catalog:default",
     "fast-glob": "catalog:default"

--- a/packages/adapters/node/rollup.config.js
+++ b/packages/adapters/node/rollup.config.js
@@ -2,10 +2,11 @@ import { defineLib } from "../../../rollup.js";
 
 export default defineLib({
   input: [
-    "./src/lib.ts",
     "./quiet/src/mod.ts",
     "./loader/src/mod.ts",
     "./register/src/mod.ts",
+    "./installer/src/mod.ts",
+    "./src/lib.ts",
   ],
   replace: (pkg) => ({
     __version__: JSON.stringify(pkg.version),

--- a/packages/framework/core/src/generative.ts
+++ b/packages/framework/core/src/generative.ts
@@ -49,7 +49,13 @@ const resolveTool = async (
     | undefined);
 };
 
-const resolveTools = async (
+const resolveTools: {
+  (tools: readonly ToolSource[], args: unknown): Promise<Tool[]>;
+  (
+    tools: readonly ToolSource[] | null | undefined,
+    args: unknown,
+  ): Promise<Tool[] | undefined>;
+} = (async (
   tools: readonly ToolSource[] | null | undefined,
   args: unknown,
 ): Promise<Tool[] | undefined> => {
@@ -68,7 +74,7 @@ const resolveTools = async (
     }
     return tools;
   }, []);
-};
+}) as typeof resolveTools;
 
 type InstructionsSource =
   | ((args: unknown) => Promise<string | undefined> | string | undefined)

--- a/packages/framework/runtime/src/agent.ts
+++ b/packages/framework/runtime/src/agent.ts
@@ -125,7 +125,7 @@ class AgentContext extends Emitter<AgentContextEvents> {
   ): R {
     const parent = this.#current.get();
     const child =
-      parent !== undefined ? parent.spawn(options) : new this(parent, options);
+      parent !== undefined ? parent.spawn(options) : this.create(options);
     return this.#current.run(child, func, child);
   }
 }

--- a/packages/framework/runtime/src/lib.ts
+++ b/packages/framework/runtime/src/lib.ts
@@ -12,6 +12,23 @@ export type {
   Message,
 } from "./message.ts";
 
+export type { AgentContextOptions, AgentContextEvents } from "./agent.ts";
+export {
+  AgentContext,
+  currentQuery,
+  currentTools,
+  useTool,
+  useTools,
+} from "./agent.ts";
+
+export { cosineDistance, indexer } from "./indexer.ts";
+
+export type { Plugin, PluginSource } from "./plugin.ts";
+export { resolvePlugin, resolvePlugins } from "./plugin.ts";
+
+export type { Toolkit, ToolkitSource } from "./toolkit.ts";
+export { resolveToolkit, resolveToolkits } from "./toolkit.ts";
+
 export type {
   IdiomDef,
   IndexDef,
@@ -41,20 +58,6 @@ export {
   createInventory,
   resolveInventory,
 } from "./inventory.ts";
-
-export type { AgentContextOptions, AgentContextEvents } from "./agent.ts";
-export {
-  AgentContext,
-  currentQuery,
-  currentTools,
-  useTool,
-  useTools,
-} from "./agent.ts";
-
-export { cosineDistance, indexer } from "./indexer.ts";
-
-export type { Plugin, PluginSource } from "./plugin.ts";
-export { resolvePlugin, resolvePlugins } from "./plugin.ts";
 
 export type { RuntimeConfigSource, RuntimeConfig } from "./runtime.ts";
 export { Runtime, embed, index, generate, resolveIdiom } from "./runtime.ts";

--- a/packages/framework/runtime/src/plugin.ts
+++ b/packages/framework/runtime/src/plugin.ts
@@ -38,11 +38,16 @@ const resolvePlugin = async (
   return await plugin;
 };
 
-const resolvePlugins = async (
+const resolvePlugins: {
+  (plugins: readonly PluginSource[]): Promise<Plugin[]>;
+  (
+    plugins: readonly PluginSource[] | null | undefined,
+  ): Promise<Plugin[] | undefined>;
+} = (async (
   plugins: readonly PluginSource[] | null | undefined,
-): Promise<Plugin[] | null> => {
+): Promise<Plugin[] | undefined> => {
   if (plugins === undefined || plugins === null) {
-    return null;
+    return undefined;
   }
   return (
     await Promise.allSettled(plugins.map((plugin) => resolvePlugin(plugin)))
@@ -52,7 +57,7 @@ const resolvePlugins = async (
     }
     return plugins;
   }, []);
-};
+}) as typeof resolvePlugins;
 
 export type { Plugin, PluginSource };
 export { resolvePlugin, resolvePlugins };

--- a/packages/framework/runtime/src/toolkit.ts
+++ b/packages/framework/runtime/src/toolkit.ts
@@ -1,0 +1,48 @@
+import type { Idiom, Tool } from "@toolcog/core";
+
+interface Toolkit {
+  readonly name: string;
+
+  readonly version?: string;
+
+  readonly tools?: () => Promise<readonly Idiom<Tool>[]>;
+}
+
+type ToolkitSource =
+  | (() => Promise<Toolkit | undefined> | Toolkit | undefined)
+  | Promise<Toolkit | undefined>
+  | Toolkit
+  | undefined;
+
+const resolveToolkit = async (
+  toolkit: ToolkitSource,
+): Promise<Toolkit | undefined> => {
+  if (typeof toolkit === "function") {
+    toolkit = toolkit();
+  }
+  return await toolkit;
+};
+
+const resolveToolkits: {
+  (toolkits: readonly ToolkitSource[]): Promise<Toolkit[]>;
+  (
+    toolkits: readonly ToolkitSource[] | null | undefined,
+  ): Promise<Toolkit[] | undefined>;
+} = (async (
+  toolkits: readonly ToolkitSource[] | null | undefined,
+): Promise<Toolkit[] | undefined> => {
+  if (toolkits === undefined || toolkits === null) {
+    return undefined;
+  }
+  return (
+    await Promise.allSettled(toolkits.map((toolkit) => resolveToolkit(toolkit)))
+  ).reduce<Toolkit[]>((toolkits, result) => {
+    if (result.status === "fulfilled" && result.value !== undefined) {
+      toolkits.push(result.value);
+    }
+    return toolkits;
+  }, []);
+}) as typeof resolveToolkits;
+
+export type { Toolkit, ToolkitSource };
+export { resolveToolkit, resolveToolkits };

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -34,7 +34,12 @@
       "@toolcog/node": ["./packages/adapters/node/src/lib.ts"],
       "@toolcog/node/quiet": ["./packages/adapters/node/quiet/src/mod.ts"],
       "@toolcog/node/loader": ["./packages/adapters/node/loader/src/mod.ts"],
-      "@toolcog/node/register": ["./packages/adapters/node/register/src/mod.ts"],
+      "@toolcog/node/register": [
+        "./packages/adapters/node/register/src/mod.ts"
+      ],
+      "@toolcog/node/installer": [
+        "./packages/adapters/node/installer/src/mod.ts"
+      ],
       "toolcog": ["./packages/toolcog/src/lib.ts"]
     },
     "resolveJsonModule": true,


### PR DESCRIPTION
Toolkits can now be loaded with `--toolkit <module>`. Multiple toolkits can be loaded by specifying multiple `--toolkit` options. Plugins can now be loaded with `--plugin <module>`. Multiple plugins can be loaded by specifying multiple `--plugin` options.

Similar to `npx`, if a toolkit or plugin module represents a package import that fails to resolve, the CLI will offer to install the missing packages. If permitted to do so, the missing packages will be installed in `~/.toolcog/packages/<hash>`, where `<hash>` is a hash of the to-be-installed package names. The requested modules will then be loaded from the ephemeral installation directory.

Loading a toolkit with `--toolkit` also attempts to load a corresponding inventory module by appending "/toolcog-inventory" to the module name, if the module represents a package import.

All loaded plugins, toolkits, and inventories are registered with the current runtime.