### PR TITLE
feat: Rename @constant doc tag to @value

### DIFF
--- a/.changeset/wicked-crabs-tell.md
+++ b/.changeset/wicked-crabs-tell.md
@@ -1,0 +1,10 @@
+---
+"@toolcog/compiler": patch
+---
+
+Rename @constant doc tag to @value.
+
+Used to document the meaning of specific values a type can take on.
+The text of @value doc tags gets inserted into generated "const" schemas
+for the corresponding literal type variant. Despite their use in "const"
+schemas, @value reads better than @constant in documentation comments.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,7 +12,7 @@ export default pluginTs.config(
       "jsdoc/check-line-alignment": "error",
       "jsdoc/check-tag-names": [
         "error",
-        { definedTags: ["constant", "id", "idiom", "instructions", "noid"] },
+        { definedTags: ["id", "idiom", "instructions", "noid", "value"] },
       ],
       "jsdoc/no-bad-blocks": "error",
       "jsdoc/require-jsdoc": "off",

--- a/packages/framework/compiler/src/comment.ts
+++ b/packages/framework/compiler/src/comment.ts
@@ -7,7 +7,7 @@ interface Comment {
   params: Record<string, string>;
   returns: string | undefined;
   idioms: string[];
-  constants: Record<string, string>;
+  values: Record<string, string>;
   tags: Record<string, string>;
 }
 
@@ -114,9 +114,9 @@ const parseTag = (
     return;
   }
 
-  if (tag === "constant") {
+  if (tag === "value") {
     const [, name, description] = parseTypedValue(ts, value, { named: true });
-    comment.constants[name] = description;
+    comment.values[name] = description;
     return;
   }
 
@@ -132,7 +132,7 @@ const parseComment = (
     params: Object.create(null) as Record<string, string>,
     returns: undefined,
     idioms: [],
-    constants: Object.create(null) as Record<string, string>,
+    values: Object.create(null) as Record<string, string>,
     tags: Object.create(null) as Record<string, string>,
   };
 
@@ -178,7 +178,7 @@ const mergeComments: {
   const params = Object.create(null) as Record<string, string>;
   let returns: string | undefined;
   const idioms = new Set<string>();
-  const constants = Object.create(null) as Record<string, string>;
+  const values = Object.create(null) as Record<string, string>;
   const tags = Object.create(null) as Record<string, string>;
 
   for (const comment of comments) {
@@ -199,8 +199,8 @@ const mergeComments: {
     for (const idiom of comment.idioms) {
       idioms.add(idiom);
     }
-    for (const constant in comment.constants) {
-      constants[constant] = comment.constants[constant]!;
+    for (const value in comment.values) {
+      values[value] = comment.values[value]!;
     }
     for (const tag in comment.tags) {
       tags[tag] = comment.tags[tag]!;
@@ -216,7 +216,7 @@ const mergeComments: {
     params,
     returns,
     idioms: [...idioms],
-    constants,
+    values,
     tags,
   };
 }) as typeof mergeComments;

--- a/packages/framework/compiler/src/schema.ts
+++ b/packages/framework/compiler/src/schema.ts
@@ -59,8 +59,8 @@ const typeToSchema = (
   type = checker.getBaseConstraintOfType(type) ?? type;
 
   if ((type.flags & ts.TypeFlags.Void) !== 0) {
-    if (description === undefined && comment?.constants !== undefined) {
-      description = comment.constants.void;
+    if (description === undefined && comment?.values !== undefined) {
+      description = comment.values.void;
     }
     return {
       ...(description !== undefined ? { description } : undefined),
@@ -69,8 +69,8 @@ const typeToSchema = (
   }
 
   if ((type.flags & ts.TypeFlags.Undefined) !== 0) {
-    if (description === undefined && comment?.constants !== undefined) {
-      description = comment.constants.undefined;
+    if (description === undefined && comment?.values !== undefined) {
+      description = comment.values.undefined;
     }
     return {
       ...(description !== undefined ? { description } : undefined),
@@ -79,8 +79,8 @@ const typeToSchema = (
   }
 
   if ((type.flags & ts.TypeFlags.Null) !== 0) {
-    if (description === undefined && comment?.constants !== undefined) {
-      description = comment.constants.null;
+    if (description === undefined && comment?.values !== undefined) {
+      description = comment.values.null;
     }
     return {
       ...(description !== undefined ? { description } : undefined),
@@ -90,8 +90,8 @@ const typeToSchema = (
 
   if ((type.flags & ts.TypeFlags.BooleanLiteral) !== 0) {
     const value = (type as ts.IntrinsicType).intrinsicName === "true";
-    if (description === undefined && comment?.constants !== undefined) {
-      description = comment.constants[String(value)];
+    if (description === undefined && comment?.values !== undefined) {
+      description = comment.values[String(value)];
     }
     return {
       ...(description !== undefined ? { description } : undefined),
@@ -101,8 +101,8 @@ const typeToSchema = (
 
   if ((type.flags & ts.TypeFlags.NumberLiteral) !== 0) {
     const value = (type as ts.NumberLiteralType).value;
-    if (description === undefined && comment?.constants !== undefined) {
-      description = comment.constants[String(value)];
+    if (description === undefined && comment?.values !== undefined) {
+      description = comment.values[String(value)];
     }
     return {
       ...(description !== undefined ? { description } : undefined),
@@ -112,8 +112,8 @@ const typeToSchema = (
 
   if ((type.flags & ts.TypeFlags.StringLiteral) !== 0) {
     const value = (type as ts.StringLiteralType).value;
-    if (description === undefined && comment?.constants !== undefined) {
-      description = comment.constants[value];
+    if (description === undefined && comment?.values !== undefined) {
+      description = comment.values[value];
     }
     return {
       ...(description !== undefined ? { description } : undefined),


### PR DESCRIPTION
Used to document the meaning of specific values a type can take on. The text of @value doc tags gets inserted into generated "const" schemas for the corresponding literal type variant. Despite their use in "const" schemas, @value reads better than @constant in documentation comments.