### PR TITLE
feat: Support comma-separated lists of toolkits in --toolkit arguments

### DIFF
--- a/.changeset/honest-dryers-study.md
+++ b/.changeset/honest-dryers-study.md
@@ -1,0 +1,7 @@
+---
+"@toolcog/node": patch
+---
+
+Support comma-separated lists of toolkits in --toolkit arguments.
+
+In addition to repeated --toolkit options.

--- a/packages/adapters/node/src/node.ts
+++ b/packages/adapters/node/src/node.ts
@@ -252,13 +252,13 @@ const createNodeCommand = (name: string): Command => {
     .option<string[]>(
       "--plugin <pluginModule...>",
       "Load the specified plugin",
-      (moduleName, moduleNames) => [...moduleNames, moduleName],
+      (moduleName, moduleNames) => [...moduleNames, ...moduleName.split(",")],
       [],
     )
     .option<string[]>(
       "--toolkit <toolkitModule...>",
       "Load the specified toolkit",
-      (moduleName, moduleNames) => [...moduleNames, moduleName],
+      (moduleName, moduleNames) => [...moduleNames, ...moduleName.split(",")],
       [],
     )
     .option<number>(


### PR DESCRIPTION
in addition to repeated --toolkit options.