### PR TITLE
feat: Add agent-scoped toolkit configuration location

### DIFF
--- a/.changeset/lovely-geese-care.md
+++ b/.changeset/lovely-geese-care.md
@@ -1,0 +1,8 @@
+---
+"@toolcog/runtime": patch
+---
+
+Add agent-scoped toolkit configuration location.
+
+Toolkits can augment the `AgentConfig` interface, and access
+the current agent's config object by calling `currentConfig()`.

--- a/packages/framework/runtime/src/indexer.ts
+++ b/packages/framework/runtime/src/indexer.ts
@@ -143,7 +143,7 @@ const indexer = (<T extends readonly unknown[]>(
 
     if (agentContext !== null) {
       agentContext.addQueryVector(query);
-      query = agentContext.decayedQueryVector();
+      query = agentContext.averageQueryVector();
     }
 
     let neighbors = nearest(model, query, options.limit);

--- a/packages/framework/runtime/src/lib.ts
+++ b/packages/framework/runtime/src/lib.ts
@@ -12,23 +12,6 @@ export type {
   Message,
 } from "./message.ts";
 
-export type { AgentContextOptions, AgentContextEvents } from "./agent.ts";
-export {
-  AgentContext,
-  currentQuery,
-  currentTools,
-  useTool,
-  useTools,
-} from "./agent.ts";
-
-export { cosineDistance, indexer } from "./indexer.ts";
-
-export type { Plugin, PluginSource } from "./plugin.ts";
-export { resolvePlugin, resolvePlugins } from "./plugin.ts";
-
-export type { Toolkit, ToolkitSource } from "./toolkit.ts";
-export { resolveToolkit, resolveToolkits } from "./toolkit.ts";
-
 export type {
   IdiomDef,
   IndexDef,
@@ -58,6 +41,28 @@ export {
   createInventory,
   resolveInventory,
 } from "./inventory.ts";
+
+export type { Plugin, PluginSource } from "./plugin.ts";
+export { resolvePlugin, resolvePlugins } from "./plugin.ts";
+
+export type { Toolkit, ToolkitSource } from "./toolkit.ts";
+export { resolveToolkit, resolveToolkits } from "./toolkit.ts";
+
+export type {
+  AgentConfig,
+  AgentContextOptions,
+  AgentContextEvents,
+} from "./agent.ts";
+export {
+  AgentContext,
+  currentConfig,
+  currentQuery,
+  currentTools,
+  useTool,
+  useTools,
+} from "./agent.ts";
+
+export { cosineDistance, indexer } from "./indexer.ts";
 
 export type { RuntimeConfigSource, RuntimeConfig } from "./runtime.ts";
 export { Runtime, embed, index, generate, resolveIdiom } from "./runtime.ts";


### PR DESCRIPTION
Toolkits can augment the `AgentConfig` interface, and access the current agent's config object by calling `currentConfig()`.