### PR TITLE
feat: Improve tool selection accuracy with prompt splitting

### DIFF
--- a/.changeset/lovely-rivers-press.md
+++ b/.changeset/lovely-rivers-press.md
@@ -1,0 +1,24 @@
+---
+"@toolcog/runtime": minor
+"@toolcog/anthropic": minor
+"@toolcog/core": minor
+"@toolcog/util": minor
+"@toolcog/openai": minor
+---
+
+Improve tool selection accuracy with prompt splitting.
+
+Split prompts into sentences, by default, and generate a separate embedding
+for each sentence. The default strategy will likely evolve over time.
+The split function can be configured with the `splitPrompt` property of
+`AgentContextOptions`.
+
+Tool selection hysteresis has been reworked to retain a rolling window of
+recent prompt embeddings. Tool selection now finds the most similar tools
+to any prompt embedding in the window, with a penalty factor applied to the
+computed distance of older prompts. The `historyPenalty` property of
+`IndexOptions` can be used to override the penalty rate for an index.
+The `promptHysteresis` property of `AgentContextOptions` can be used to
+override the length of the prompt history window for a given agent.
+
+Add a small `nlp` utility library with the sentence splitting implementation.

--- a/packages/framework/core/src/idiom.ts
+++ b/packages/framework/core/src/idiom.ts
@@ -69,14 +69,48 @@ const defineIdioms: {
  * Options for configuring an {@link Index} function.
  */
 interface IndexConfig extends EmbedderConfig {
+  /**
+   * The default maximum number of results to return.
+   */
   limit?: number | undefined;
+
+  /**
+   * The default distance penalty rate to apply to older prompts.
+   * Used to artificially reduce the relevance of older prompts without
+   * entirely eliminating their influence.
+   *
+   * The penalty factor for any given prompt embedding is computed as
+   * `Math.pow(1 + historyPenalty, indexFromEnd)`. The distance between a
+   * given prompt embedding and an index entry is multiplied by the penalty
+   * factory to obtain an effective distance metric. The effective distance
+   * metric is then used to rank the similarity of the match.
+   */
+  historyPenalty?: number | undefined;
 }
 
 /**
  * Options for controlling an {@link Index} call.
  */
 interface IndexOptions extends EmbedderOptions {
+  /**
+   * The maximum number of results to return.
+   */
   limit?: number | undefined;
+
+  /**
+   * The distance penalty rate to apply to older prompts.
+   * Used to artificially reduce the relevance of older prompts without
+   * entirely eliminating their influence.
+   *
+   * The penalty factor for any given prompt embedding is computed as
+   * `Math.pow(1 + historyPenalty, indexFromEnd)`. The distance between a
+   * given prompt embedding and an index entry is multiplied by the penalty
+   * factory to obtain an effective distance metric. The effective distance
+   * metric is then used to rank the similarity of the match.
+   *
+   * @default 0.1
+   */
+  historyPenalty?: number | undefined;
 }
 
 /**
@@ -85,8 +119,8 @@ interface IndexOptions extends EmbedderOptions {
 interface Index<T extends readonly unknown[]> {
   /**
    * Returns the indexed values that are most similar to the given `query`.
-   * The `query` will be converted into an `EmbeddingVector`, if it isn't
-   * already one.
+   * `query` should be a string, but is typed as `unknown` to make `Index`
+   * compatible with `ToolSource`.
    */
   (query?: unknown, options?: IndexOptions): Promise<T[number][]>;
 

--- a/packages/framework/runtime/src/lib.ts
+++ b/packages/framework/runtime/src/lib.ts
@@ -56,7 +56,6 @@ export type {
 export {
   AgentContext,
   currentConfig,
-  currentQuery,
   currentTools,
   useTool,
   useTools,

--- a/packages/framework/runtime/src/runtime.ts
+++ b/packages/framework/runtime/src/runtime.ts
@@ -16,7 +16,6 @@ import type {
   GeneratorOptions,
   Generator,
 } from "@toolcog/core";
-import { AgentContext } from "./agent.ts";
 import { indexer } from "./indexer.ts";
 import type { Plugin, PluginSource } from "./plugin.ts";
 import { resolvePlugins } from "./plugin.ts";
@@ -199,19 +198,8 @@ class Runtime {
 
   async generate(args: unknown, options?: GeneratorOptions): Promise<unknown> {
     options = this.generatorOptions(options);
-
-    let context: AgentContext | null = null;
-    if (typeof args === "string") {
-      context = AgentContext.get();
-      context?.setQuery(args);
-    }
-
-    try {
-      const generator = await this.generator(options);
-      return await generator(args, options);
-    } finally {
-      context?.setQuery(undefined);
-    }
+    const generator = await this.generator(options);
+    return await generator(args, options);
   }
 
   resolveIdiom(id: string, value: unknown): Embeddings | undefined {

--- a/packages/framework/util/nlp/package.json
+++ b/packages/framework/util/nlp/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@toolcog/util/nlp",
+  "type": "module"
+}

--- a/packages/framework/util/nlp/src/mod.ts
+++ b/packages/framework/util/nlp/src/mod.ts
@@ -1,0 +1,2 @@
+export type { SplitSentencesOptions } from "./sentences.ts";
+export { splitSentences } from "./sentences.ts";

--- a/packages/framework/util/nlp/src/sentences.test.ts
+++ b/packages/framework/util/nlp/src/sentences.test.ts
@@ -1,0 +1,297 @@
+import { it, expect } from "vitest";
+import { splitSentences } from "./sentences.ts";
+
+it("should split basic sentences separated by periods", () => {
+  const text = "This is the first sentence. This is the second sentence.";
+  expect(splitSentences(text)).toEqual([
+    "This is the first sentence.",
+    "This is the second sentence.",
+  ]);
+});
+
+it("should correctly split sentences without abbreviations", () => {
+  const text =
+    "This is a sentence. And here is another one. Yet another sentence!";
+  expect(splitSentences(text)).toEqual([
+    "This is a sentence.",
+    "And here is another one.",
+    "Yet another sentence!",
+  ]);
+});
+
+it("should not split sentences after abbreviations", () => {
+  const text =
+    "Dr. Smith went to Washington, D.C. He arrived at 3 p.m. It was late.";
+  expect(splitSentences(text)).toEqual([
+    "Dr. Smith went to Washington, D.C.",
+    "He arrived at 3 p.m. It was late.",
+  ]);
+});
+
+it("should correctly split sentences containing quotes", () => {
+  const text = '"Wait... what?" she asked. "Are you sure?"';
+  expect(splitSentences(text)).toEqual([
+    '"Wait... what?" she asked.',
+    '"Are you sure?"',
+  ]);
+});
+
+it("should not split sentences within quotes", () => {
+  const text =
+    'He said, "This is a test. Is it working? I hope so." Then he left.';
+  expect(splitSentences(text)).toEqual([
+    'He said, "This is a test. Is it working? I hope so."',
+    "Then he left.",
+  ]);
+});
+
+it("should correctly split sentences containing parentheses", () => {
+  const text = "She smiled (knowing he was right). Then she left.";
+  expect(splitSentences(text)).toEqual([
+    "She smiled (knowing he was right).",
+    "Then she left.",
+  ]);
+});
+
+it("should correctly split sentences that start with parentheses", () => {
+  const text = "He smiled. (It was a sunny day.) She walked away.";
+  expect(splitSentences(text)).toEqual([
+    "He smiled.",
+    "(It was a sunny day.)",
+    "She walked away.",
+  ]);
+});
+
+it("should not split sentences within parentheses", () => {
+  const text = "The equation (E = mc^2) is famous. Do you know it?";
+  expect(splitSentences(text)).toEqual([
+    "The equation (E = mc^2) is famous.",
+    "Do you know it?",
+  ]);
+});
+
+it("should correctly split sentences containing quotes and parentheses", () => {
+  const text = '"Hello!" (She waved.) "How are you?"';
+  expect(splitSentences(text)).toEqual([
+    '"Hello!"',
+    "(She waved.)",
+    '"How are you?"',
+  ]);
+});
+
+it("should not split sentences with unmatched quotes or parentheses", () => {
+  const text = 'He said, "This is tricky.';
+  expect(splitSentences(text)).toEqual(['He said, "This is tricky.']);
+});
+
+it("should handle Unicode punctuation and characters", () => {
+  const text = "こんにちは。お元気ですか？私は元気です！";
+  expect(splitSentences(text)).toEqual([
+    "こんにちは。",
+    "お元気ですか？",
+    "私は元気です！",
+  ]);
+});
+
+it("should not split sentences when a lowercase letter follows a newline", () => {
+  const text = "This is a sentence\nwith a newline in its midst.";
+  expect(splitSentences(text)).toEqual([
+    "This is a sentence\nwith a newline in its midst.",
+  ]);
+});
+
+it("should correctly split sentences with multiple sentence-ending punctuation marks", () => {
+  const text = "What happened?! Are you okay?? Yes!! I am fine.";
+  expect(splitSentences(text)).toEqual([
+    "What happened?!",
+    "Are you okay??",
+    "Yes!!",
+    "I am fine.",
+  ]);
+});
+
+it("should split sentences with unmatched closing punctuation", () => {
+  const text = 'She said, "Hello there! Then she left.';
+  expect(splitSentences(text)).toEqual([
+    'She said, "Hello there! Then she left.',
+  ]);
+});
+
+it("should split sentences with unmatched closing parentheses", () => {
+  const text = "He thought about it (for a long time. Then he decided.";
+  expect(splitSentences(text)).toEqual([
+    "He thought about it (for a long time. Then he decided.",
+  ]);
+});
+
+it("should split sentences containing emojis", () => {
+  const text = "I am happy 😊 Are you? Yes 😄";
+  expect(splitSentences(text)).toEqual(["I am happy 😊 Are you?", "Yes 😄"]);
+});
+
+it("should handle sentences containing numbers and periods'", () => {
+  const text = "Version 2.0 has been released. Please update.";
+  expect(splitSentences(text)).toEqual([
+    "Version 2.0 has been released.",
+    "Please update.",
+  ]);
+});
+
+it("should handle sentences with multiple abbreviations", () => {
+  const text = "Dr. Smith, Ph.D., arrived at 5 p.m. It was late.";
+  expect(splitSentences(text)).toEqual([
+    "Dr. Smith, Ph.D., arrived at 5 p.m. It was late.",
+  ]);
+});
+
+it("should not split sentences with abbreviations followed by lowercase letters", () => {
+  const text = "We arrived at 3 p.m. and had dinner.";
+  expect(splitSentences(text)).toEqual([
+    "We arrived at 3 p.m. and had dinner.",
+  ]);
+});
+
+it("should handle abbreviations at the ends of sentences", () => {
+  const text = "The meeting is at 5 p.m. Please be on time.";
+  expect(splitSentences(text)).toEqual([
+    "The meeting is at 5 p.m. Please be on time.",
+  ]);
+});
+
+it("should support custom abbreviations", () => {
+  const text = "Mx. Taylor is here. They are ready to see you.";
+  expect(
+    splitSentences(text, {
+      abbreviations: ["Mx."],
+    }),
+  ).toEqual(["Mx. Taylor is here.", "They are ready to see you."]);
+});
+
+it("should split sentences with mixed scripts and punctuation", () => {
+  const text =
+    "English sentence. 中文句子。Another English sentence! これは日本語の文章です。";
+  expect(splitSentences(text)).toEqual([
+    "English sentence.",
+    "中文句子。",
+    "Another English sentence!",
+    "これは日本語の文章です。",
+  ]);
+});
+
+it("should treat text with no sentence-ending punctuation as a single sentence", () => {
+  const text = "This is a sentence without an ending";
+  expect(splitSentences(text)).toEqual([
+    "This is a sentence without an ending",
+  ]);
+});
+
+it("should correctly handle sentences containing URLs and email addresses", () => {
+  const text =
+    "Visit us at www.example.com. Send an email to info@example.com. Thank you!";
+  expect(splitSentences(text)).toEqual([
+    "Visit us at www.example.com.",
+    "Send an email to info@example.com.",
+    "Thank you!",
+  ]);
+});
+
+it("should split sentences containing decimal numbers", () => {
+  const text = "The price is $3.99. Is that affordable?";
+  expect(splitSentences(text)).toEqual([
+    "The price is $3.99.",
+    "Is that affordable?",
+  ]);
+});
+
+it("should handle sentences containing ellipses", () => {
+  const text = "Well... I am not sure. Are you?";
+  expect(splitSentences(text)).toEqual(["Well... I am not sure.", "Are you?"]);
+});
+
+it("should handle sentences containing newlines within unmatched quotes", () => {
+  const text =
+    'He said, "This is a sentence\nthat spans multiple lines\nwithout closing the quote.\nSo it should not split.';
+  expect(splitSentences(text)).toEqual([
+    'He said, "This is a sentence\nthat spans multiple lines\nwithout closing the quote.\nSo it should not split.',
+  ]);
+});
+
+it("should handle sentences with multiple unmatched closing punctuation characters", () => {
+  const text = "He thought). Then he decided.";
+  expect(splitSentences(text)).toEqual(["He thought).", "Then he decided."]);
+});
+
+it("should handle text with only whitespace", () => {
+  const text = "   \n  \t  ";
+  expect(splitSentences(text)).toEqual([]);
+});
+
+it("should handle empty string input", () => {
+  const text = "";
+  expect(splitSentences(text)).toEqual([]);
+});
+
+it("should handle sentences that start with mixed case letters", () => {
+  const text = "this is a sentence. And this is another one.";
+  expect(splitSentences(text)).toEqual([
+    "this is a sentence.",
+    "And this is another one.",
+  ]);
+});
+
+it("should handle sentences with special characters", () => {
+  const text = "Hello @user! Have you seen #topic? It's trending.";
+  expect(splitSentences(text)).toEqual([
+    "Hello @user!",
+    "Have you seen #topic?",
+    "It's trending.",
+  ]);
+});
+
+it("should handle sentences with full-width punctuation", () => {
+  const text = "これは日本語の文章です。「こんにちは！」と彼は言った。";
+  expect(splitSentences(text)).toEqual([
+    "これは日本語の文章です。",
+    "「こんにちは！」",
+    "と彼は言った。",
+  ]);
+});
+
+it("should split sentences ending with punctuation and newlines", () => {
+  const text = "First sentence.\nSecond sentence!\n";
+  expect(splitSentences(text)).toEqual(["First sentence.", "Second sentence!"]);
+});
+
+it("should split sentences after abbreviations at the end of a line", () => {
+  const text =
+    "Dr.\nSmith went to Washington, D.C.\nHe arrived at 3 p.m.\nIt was late.";
+  expect(splitSentences(text)).toEqual([
+    "Dr.\nSmith went to Washington, D.C.",
+    "He arrived at 3 p.m.\nIt was late.",
+  ]);
+});
+
+it("should correctly handle sentences with nested quotes", () => {
+  const text = `He said, "She replied, 'I heard him shout, "Help!"' and ran away." What do you think?`;
+  expect(splitSentences(text)).toEqual([
+    `He said, "She replied, 'I heard him shout, "Help!"' and ran away."`,
+    "What do you think?",
+  ]);
+});
+
+it("should correctly handle sentences with multiple punctuation marks", () => {
+  const text = "Wait... What?! Are you serious??? Yes!!!";
+  expect(splitSentences(text)).toEqual([
+    "Wait... What?!",
+    "Are you serious???",
+    "Yes!!!",
+  ]);
+});
+
+it("should handle sentences with code snippets and periods", () => {
+  const text = "Use the command `npm install`. Then run `npm start`.";
+  expect(splitSentences(text)).toEqual([
+    "Use the command `npm install`.",
+    "Then run `npm start`.",
+  ]);
+});

--- a/packages/framework/util/nlp/src/sentences.ts
+++ b/packages/framework/util/nlp/src/sentences.ts
@@ -1,0 +1,199 @@
+interface SplitSentencesOptions {
+  abbreviations?: readonly string[] | undefined;
+}
+
+const splitSentences = (
+  text: string,
+  options?: SplitSentencesOptions,
+): string[] => {
+  text = text.trim();
+  if (text.length === 0) {
+    return [];
+  }
+
+  const abbreviationsRegex =
+    options?.abbreviations !== undefined ?
+      buildAbbreviationsRegex(options.abbreviations)
+    : defaultAbbreviationsRegex;
+
+  const sentences: string[] = [];
+  let match: RegExpExecArray | null;
+  let lastIndex = 0;
+
+  while ((match = sentenceEndRegex.exec(text)) !== null) {
+    const endIndex = match.index + match[0].length;
+    const punctuation = match[1] ?? match[2]!;
+    const segment = text.slice(lastIndex, endIndex).trim();
+
+    const quoteStack: string[] = [];
+    const parenStack: string[] = [];
+
+    for (const char of segment) {
+      if (char === '"' || char === "'") {
+        if (quoteStack[quoteStack.length - 1] === char) {
+          quoteStack.pop();
+        } else {
+          quoteStack.push(char);
+        }
+      } else if (char in openQuotes) {
+        quoteStack.push(char);
+      } else if (char in closeQuotes) {
+        if (quoteStack[quoteStack.length - 1] === closeQuotes[char]!) {
+          quoteStack.pop();
+        }
+      } else if (char in openParens) {
+        parenStack.push(char);
+      } else if (char in closeParens) {
+        if (parenStack[parenStack.length - 1] === closeParens[char]!) {
+          parenStack.pop();
+        }
+      }
+    }
+
+    if (abbreviationsRegex.test(segment)) {
+      // Don't split after abbreviations.
+      continue;
+    }
+
+    if (quoteStack.length !== 0 || parenStack.length !== 0) {
+      // Don't split inside quotes or parentheses.
+      continue;
+    }
+
+    if (
+      match[1] !== undefined &&
+      /^[\s\u00A0]*([a-z])/u.exec(text.slice(endIndex)) !== null
+    ) {
+      // Don't split if a lowercase letter follows half-width punctuation.
+      continue;
+    }
+
+    // Add the sentence.
+    sentences.push(
+      text.slice(lastIndex, match.index + punctuation.length).trim(),
+    );
+    lastIndex = endIndex;
+  }
+
+  // Add any remaining text as the last sentence.
+  if (lastIndex < text.length) {
+    const lastSentence = text.slice(lastIndex).trim();
+    if (/\S/u.test(lastSentence)) {
+      sentences.push(lastSentence);
+    }
+  }
+
+  return sentences.filter((sentence) => /\S/u.test(sentence));
+};
+
+const buildAbbreviationsRegex = (abbreviations: readonly string[]): RegExp => {
+  return new RegExp(`(?:${abbreviations.join("|")})$`, "iu");
+};
+
+const defaultAbbreviations: readonly string[] = [
+  "Mr.",
+  "Mrs.",
+  "Ms.",
+  "Dr.",
+  "Prof.",
+  "Sr.",
+  "Jr.",
+  "St.",
+  "vs.",
+  "etc.",
+  "i.e.",
+  "e.g.",
+  "Fig.",
+  "Inc.",
+  "Ltd.",
+  "Co.",
+  "Corp.",
+  "Jan.",
+  "Feb.",
+  "Mar.",
+  "Apr.",
+  "Jun.",
+  "Jul.",
+  "Aug.",
+  "Sep.",
+  "Sept.",
+  "Oct.",
+  "Nov.",
+  "Dec.",
+  "U.S.",
+  "U.K.",
+  "Ph.D.",
+  "M.D.",
+  "a.m.",
+  "p.m.",
+  "No.",
+  "Mt.",
+  "ft.",
+  "in.",
+  "Ave.",
+  "Blvd.",
+  "Rd.",
+  "Bros.",
+];
+
+const defaultAbbreviationsRegex = buildAbbreviationsRegex(defaultAbbreviations);
+
+// Regular expression to match sentence-ending punctuation. Captures sequences
+// of sentence-ending punctuation marks (e.g., ".", "!", "?"), possibly
+// followed by closing punctuation characters like quotes or parentheses.
+//
+// For half-width punctuation marks (".", "!", "?"):
+// - Matches one or more punctuation marks, followed by optional closing characters.
+// - Ensures that the punctuation is followed by whitespace, an opening
+//   quote/parenthesis, or the end of the string. This helps prevent splitting
+//   within abbreviations or decimal numbers.
+//
+// For full-width punctuation marks ("。", "！", "？"):
+// - Matches one or more punctuation marks, followed by optional closing characters.
+// - Does not require any specific character to follow. This accommodates
+//   languages like Japanese, where sentences may not have spaces between them.
+const sentenceEndRegex =
+  /((?<!\.)(?:[.!?](?!\.))+['"”’»」』)\]}]*(?=\s|["'"“‘«「『([{\u2018-\u201F]|$))|([。！？]['"”’»」』)\]}]*)/gu;
+
+const openQuotes: { readonly [open: string]: string } = {
+  '"': '"',
+  "'": "'",
+  "“": "”",
+  "‘": "’",
+  "«": "»",
+  "「": "」",
+  "『": "』",
+};
+
+const closeQuotes: { readonly [close: string]: string } = {
+  '"': '"',
+  "'": "'",
+  "”": "“",
+  "’": "‘",
+  "»": "«",
+  "」": "「",
+  "』": "『",
+};
+
+const openParens: { readonly [open: string]: string } = {
+  "(": ")",
+  "[": "]",
+  "{": "}",
+  "（": "）",
+  "【": "】",
+  "「": "」",
+  "『": "』",
+};
+
+const closeParens: { readonly [close: string]: string } = {
+  ")": "(",
+  "]": "[",
+  "}": "{",
+  "）": "（",
+  "】": "【",
+  "」": "「",
+  "』": "『",
+};
+
+export type { SplitSentencesOptions };
+export { splitSentences };

--- a/packages/framework/util/nlp/tsconfig.json
+++ b/packages/framework/util/nlp/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/packages/framework/util/nlp/typedoc.json
+++ b/packages/framework/util/nlp/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "extends": ["../../../../typedoc.base.json"],
+  "entryPoints": ["src/mod.ts"]
+}

--- a/packages/framework/util/package.json
+++ b/packages/framework/util/package.json
@@ -100,6 +100,11 @@
       "import": "./dist/tui.js",
       "require": "./dist/tui.cjs"
     },
+    "./nlp": {
+      "types": "./dist/nlp.d.ts",
+      "import": "./dist/nlp.js",
+      "require": "./dist/nlp.cjs"
+    },
     "./graphql": {
       "types": "./dist/graphql.d.ts",
       "import": "./dist/graphql.js",

--- a/packages/framework/util/rollup.config.js
+++ b/packages/framework/util/rollup.config.js
@@ -19,5 +19,6 @@ export default [
   ...defineLib({ input: "./timer/src/mod.ts" }),
   ...defineLib({ input: "./tty/src/mod.ts" }),
   ...defineLib({ input: "./tui/src/mod.ts" }),
+  ...defineLib({ input: "./nlp/src/mod.ts" }),
   ...defineLib({ input: "./graphql/src/mod.ts" }),
 ];

--- a/packages/plugins/anthropic/src/generator.ts
+++ b/packages/plugins/anthropic/src/generator.ts
@@ -96,6 +96,8 @@ const generate = (async (
   args: unknown,
   options?: AnthropicGeneratorOptions,
 ): Promise<unknown> => {
+  const context = AgentContext.getOrCreate();
+
   const client =
     options?.anthropic instanceof Anthropic ?
       options.anthropic
@@ -115,6 +117,9 @@ const generate = (async (
     args = undefined;
   } else {
     instructions = await resolveInstructions(options?.instructions, args);
+  }
+  if (instructions !== undefined) {
+    context?.addPrompt(instructions);
   }
 
   const parametersSchema = options?.parameters;
@@ -156,8 +161,6 @@ const generate = (async (
     : undefined;
 
   let toolChoice = options?.tool_choice;
-
-  const context = AgentContext.getOrCreate();
 
   const system = options?.system;
 

--- a/packages/plugins/openai/src/generator.ts
+++ b/packages/plugins/openai/src/generator.ts
@@ -140,6 +140,8 @@ const generate = (async (
   args: unknown,
   options?: OpenAIGeneratorOptions,
 ): Promise<unknown> => {
+  const context = AgentContext.getOrCreate();
+
   const client =
     options?.openai instanceof OpenAI ?
       options.openai
@@ -159,6 +161,9 @@ const generate = (async (
     args = undefined;
   } else {
     instructions = await resolveInstructions(options?.instructions, args);
+  }
+  if (instructions !== undefined) {
+    context?.addPrompt(instructions);
   }
 
   let jsonMode = options?.jsonMode;
@@ -248,8 +253,6 @@ const generate = (async (
     tools !== undefined && tools.length !== 0 ?
       tools.map(toOpenAITool)
     : undefined;
-
-  const context = AgentContext.getOrCreate();
 
   const systemMessage: OpenAI.ChatCompletionSystemMessageParam | undefined =
     options?.system !== undefined ?

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -29,6 +29,7 @@
       "@toolcog/util/timer": ["./packages/framework/util/timer/src/mod.ts"],
       "@toolcog/util/tty": ["./packages/framework/util/tty/src/mod.ts"],
       "@toolcog/util/tui": ["./packages/framework/util/tui/src/mod.ts"],
+      "@toolcog/util/nlp": ["./packages/framework/util/nlp/src/mod.ts"],
       "@toolcog/util/graphql": ["./packages/framework/util/graphql/src/mod.ts"],
       "@toolcog/anthropic": ["./packages/plugins/anthropic/src/lib.ts"],
       "@toolcog/openai": ["./packages/plugins/openai/src/lib.ts"],

--- a/turbo.json
+++ b/turbo.json
@@ -18,7 +18,9 @@
         "rollup.config.js",
         ".toolcog/precache.yaml",
         "src/**",
-        "*/src/**"
+        "*/src/**",
+        "!src/**/*.test.ts",
+        "!*/src/**/*.test.ts"
       ],
       "outputs": ["dist/**", "toolcog-manifest.yaml"],
       "outputLogs": "new-only",


### PR DESCRIPTION
Split prompts into sentences, by default, and generate a separate embedding for each sentence. The default strategy will likely evolve over time. The split function can be configured with the `splitPrompt` property of `AgentContextOptions`.

Tool selection hysteresis has been reworked to retain a rolling window of recent prompt embeddings. Tool selection now finds the most similar tools to any prompt embedding in the window, with a penalty factor applied to the computed distance of older prompts. The `historyPenalty` property of `IndexOptions` can be used to override the penalty rate for an index. The `promptHysteresis` property of `AgentContextOptions` can be used to override the length of the prompt history window for a given agent.

Add a small `nlp` utility library with the sentence splitting implementation.