### PR TITLE
fix: Properly serialize GraphQL literal input values

### DIFF
--- a/.changeset/itchy-windows-own.md
+++ b/.changeset/itchy-windows-own.md
@@ -1,0 +1,12 @@
+---
+"@toolcog/util": patch
+---
+
+Properly serialize GraphQL literal input values.
+
+Enum value literals must be wrapped by the `enumValue` function to ensure
+proper serialization. Enum values are represented as strings in TypeScript,
+but they must be serialized as unquoted identifiers in GraphQL arguments.
+The `enumValue` function returns an object with a private symbol that
+disambiguates enum value literals from string literals. Note that this
+constraint only applies to literal arguments, not to spliced variables.

--- a/packages/framework/util/graphql/src/graphql.test.ts
+++ b/packages/framework/util/graphql/src/graphql.test.ts
@@ -1,5 +1,5 @@
 import { it, expect } from "vitest";
-import { formatQuery } from "./graphql.ts";
+import { enumValue, formatQuery, formatMutation } from "./graphql.ts";
 
 it("should format queries", () => {
   const query = formatQuery({
@@ -267,6 +267,31 @@ it("should format queries with inline fragments", () => {
       mtime
       ctime
     }
+  }
+}`);
+});
+
+it("should format mutations with input values", () => {
+  const mutation = formatMutation({
+    post: {
+      arguments: {
+        input: {
+          value: {
+            title: "New Idea",
+            category: enumValue("IDEAS"),
+          },
+        },
+      },
+      fields: {
+        title: "String!",
+        message: "String!",
+      },
+    },
+  });
+  expect(mutation).toBe(`mutation {
+  post(input: { title: "New Idea", category: IDEAS }) {
+    title
+    message
   }
 }`);
 });

--- a/packages/framework/util/graphql/src/mod.ts
+++ b/packages/framework/util/graphql/src/mod.ts
@@ -43,6 +43,7 @@ export type {
 } from "./graphql.ts";
 export {
   defineSelection,
+  enumValue,
   formatOperation,
   formatQuery,
   formatMutation,


### PR DESCRIPTION
Enum value literals must be wrapped by the `enumValue` function to ensure proper serialization. Enum values are represented as strings in TypeScript, but they must be serialized as unquoted identifiers in GraphQL arguments. The `enumValue` function returns an object with a private symbol that disambiguates enum value literals from string literals. Note that this constraint only applies to literal arguments, not to spliced variables.