### PR TITLE
feat: Add command line options to control REPL output

### DIFF
--- a/.changeset/brown-squids-sing.md
+++ b/.changeset/brown-squids-sing.md
@@ -1,0 +1,24 @@
+---
+"@toolcog/runtime": minor
+"@toolcog/anthropic": minor
+"@toolcog/repl": minor
+"@toolcog/openai": minor
+"@toolcog/node": minor
+---
+
+Add command line options to control REPL output.
+
+The `--print-markdown` options preserves markdown formatting in LLM responses.
+Without this option, LLM responses will be ANSI stylized with their markdown
+syntax removed, making them more readable. With this option, LLM responses
+will be ANSI stylized, while retaining their markdown syntax.
+
+The `--print-tools` options prints the list of tools provided to the LLM
+for each generation call.
+
+The `--print-tool-args` prints the arguments the LLM provides when calling
+a tool.
+
+The `--print-tool-results` prints the return value of an LLN tool call.
+Tool results are now omitted from the output by default, as they can be
+quite verbose.

--- a/packages/adapters/node/src/node.ts
+++ b/packages/adapters/node/src/node.ts
@@ -26,6 +26,185 @@ import {
   loadOrInstallModules,
 } from "@toolcog/node/installer";
 
+interface NodeCommandOptions {
+  config?: string | boolean | undefined;
+  plugin?: string[] | undefined;
+  toolkit?: string[] | undefined;
+  toolLimit?: number | undefined;
+  inventory?: string | boolean | undefined;
+  generativeModel?: string | undefined;
+  embeddingModel?: string | undefined;
+  printMarkdown?: boolean | undefined;
+  printTools?: boolean | undefined;
+  printToolArgs?: boolean | undefined;
+  printToolResults?: boolean | undefined;
+  eval?: string | undefined;
+  print?: string | boolean | undefined;
+  interactive?: boolean | undefined;
+}
+
+const runNodeCommand = async (
+  scriptFile: string | undefined,
+  options: NodeCommandOptions,
+): Promise<void> => {
+  const configFile =
+    typeof options.config === "string" ? options.config
+    : options.config === true ? configFileName
+    : undefined;
+
+  const inventoryGlob =
+    typeof options.inventory === "string" ? options.inventory
+    : options.inventory === true ? `**/${inventoryFileName}`
+    : undefined;
+
+  const code =
+    options.eval ??
+    (typeof options.print === "string" ? options.print : undefined);
+  const print = options.print !== undefined && options.print !== false;
+  const interactive = options.interactive ?? false;
+
+  let runtime: Runtime | null;
+  if (configFile !== undefined) {
+    const configPath = resolvePath(process.cwd(), configFile);
+    const configModule = (await import(configPath)) as {
+      default: RuntimeConfigSource;
+    };
+    runtime = await Runtime.create(configModule.default);
+  } else {
+    runtime = Runtime.get();
+  }
+
+  let agentContextOptions: AgentContextOptions | undefined;
+  if (runtime !== null) {
+    if (options.generativeModel !== undefined) {
+      runtime.generatorConfig.model = options.generativeModel;
+    }
+    if (options.embeddingModel !== undefined) {
+      runtime.embedderConfig.model = options.embeddingModel;
+    }
+
+    const plugins = await loadPlugins(options.plugin);
+    for (const plugin of plugins) {
+      runtime.addPlugin(plugin);
+    }
+
+    const [toolkits, inventories] = await loadToolkits(options.toolkit);
+    for (const toolkit of toolkits) {
+      runtime.addToolkit(toolkit);
+    }
+    for (const inventory of inventories) {
+      runtime.addInventory(inventory);
+    }
+
+    if (inventoryGlob !== undefined) {
+      const inventoryFiles = await glob(inventoryGlob);
+      for (const inventoryFile of inventoryFiles) {
+        const inventory = parseInventory(
+          await readFile(inventoryFile, "utf-8"),
+        );
+        runtime.addInventory(inventory);
+      }
+    }
+
+    agentContextOptions = {
+      tools: [
+        await runtime.toolIndex({
+          limit: options.toolLimit,
+        }),
+      ],
+    };
+  }
+
+  await Runtime.run(runtime, async () => {
+    // Evaluate input in an agent context.
+    await AgentContext.spawn(agentContextOptions, async () => {
+      // Run script, if not evaluating non-interactive code.
+      if (scriptFile !== undefined && (code === undefined || interactive)) {
+        const scriptPath = resolvePath(process.cwd(), scriptFile);
+        await import(scriptPath);
+        return;
+      }
+
+      // Instantiate a REPL to evaluate code.
+      const repl = new Repl({
+        printMarkdown: options?.printMarkdown,
+        printTools: options?.printTools,
+        printToolArgs: options?.printToolArgs,
+        printToolResults: options?.printToolResults,
+      });
+
+      // Evaluate the builtin prelude.
+      await repl.evalPrelude();
+
+      // Check if a code argument was provided.
+      if (code !== undefined) {
+        // Evaluate the code argument.
+        const bindings = await repl.evalCode(code);
+        // Check if the result should be printed.
+        if (print) {
+          // Print the result variable.
+          repl.output.write(repl.formatValue(bindings._1) + "\n");
+        }
+      }
+
+      // Check if the REPL should be run.
+      if (interactive || (code === undefined && process.stdin.isTTY)) {
+        // Stream responses when running the REPL.
+        if (runtime !== null && runtime.generatorConfig.stream == undefined) {
+          runtime.generatorConfig.stream = true;
+        }
+
+        // Print the REPL banner.
+        repl.printBanner();
+
+        // Run the REPL session.
+        await repl.run();
+      }
+    });
+  });
+};
+
+const createNodeCommand = (name: string): Command => {
+  return new Command(name)
+    .description("Run toolcog programs with Node.js")
+    .option(`-c, --config [${configFileName}]`, "Load config from a file")
+    .option<string[]>(
+      "--plugin <pluginModule...>",
+      "Load the specified plugin",
+      (moduleName, moduleNames) => [...moduleNames, ...moduleName.split(",")],
+      [],
+    )
+    .option<string[]>(
+      "--toolkit <toolkitModule...>",
+      "Load the specified toolkit",
+      (moduleName, moduleNames) => [...moduleNames, ...moduleName.split(",")],
+      [],
+    )
+    .option<number>(
+      "--tool-limit <count>",
+      "Maximum number of tools to select",
+      (value: string) => parseInt(value),
+      10,
+    )
+    .option(`--inventory [**/${inventoryFileName}]`, "Inventory files to load")
+    .option("--generative-model <model>", "The generative model to use")
+    .option("--embedding-model <model>", "The embedding model to use")
+    .option("--print-markdown", "Print markdown formatting in LLM responses")
+    .option("--print-tools", "Print LLM tool selections")
+    .option("--print-tool-args", "Print arguments to LLM tool calls")
+    .option("--print-tool-results", "Print results of LLM tool calls")
+    .option("-e, --eval <code>", "Evaluate code")
+    .option("-p, --print [code]", "Evaluate code and print the result")
+    .option(
+      "-i, --interactive",
+      "Start the REPL even if stdin does not appear to be a terminal",
+    )
+    .argument("[script.ts]", "The script to execute")
+    .action(runNodeCommand);
+};
+
+const configFileName = "toolcog.config.ts";
+
 const loadPlugins = async (
   moduleNames: readonly string[] | undefined,
 ): Promise<Plugin[]> => {
@@ -112,172 +291,6 @@ const loadToolkits = async (
   }
 
   return [toolkits, inventories];
-};
-
-interface NodeCommandOptions {
-  config?: string | boolean | undefined;
-  plugin?: string[] | undefined;
-  toolkit?: string[] | undefined;
-  toolLimit?: number | undefined;
-  inventory?: string | boolean | undefined;
-  generativeModel?: string | undefined;
-  embeddingModel?: string | undefined;
-  eval?: string | undefined;
-  print?: string | boolean | undefined;
-  interactive?: boolean | undefined;
-}
-
-const configFileName = "toolcog.config.ts";
-
-const runNodeCommand = async (
-  scriptFile: string | undefined,
-  options: NodeCommandOptions,
-): Promise<void> => {
-  const configFile =
-    typeof options.config === "string" ? options.config
-    : options.config === true ? configFileName
-    : undefined;
-
-  const inventoryGlob =
-    typeof options.inventory === "string" ? options.inventory
-    : options.inventory === true ? `**/${inventoryFileName}`
-    : undefined;
-
-  const code =
-    options.eval ??
-    (typeof options.print === "string" ? options.print : undefined);
-  const print = options.print !== undefined && options.print !== false;
-  const interactive = options.interactive ?? false;
-
-  let runtime: Runtime | null;
-  if (configFile !== undefined) {
-    const configPath = resolvePath(process.cwd(), configFile);
-    const configModule = (await import(configPath)) as {
-      default: RuntimeConfigSource;
-    };
-    runtime = await Runtime.create(configModule.default);
-  } else {
-    runtime = Runtime.get();
-  }
-
-  let agentContextOptions: AgentContextOptions | undefined;
-  if (runtime !== null) {
-    if (options.generativeModel !== undefined) {
-      runtime.generatorConfig.model = options.generativeModel;
-    }
-    if (options.embeddingModel !== undefined) {
-      runtime.embedderConfig.model = options.embeddingModel;
-    }
-
-    const plugins = await loadPlugins(options.plugin);
-    for (const plugin of plugins) {
-      runtime.addPlugin(plugin);
-    }
-
-    const [toolkits, inventories] = await loadToolkits(options.toolkit);
-    for (const toolkit of toolkits) {
-      runtime.addToolkit(toolkit);
-    }
-    for (const inventory of inventories) {
-      runtime.addInventory(inventory);
-    }
-
-    if (inventoryGlob !== undefined) {
-      const inventoryFiles = await glob(inventoryGlob);
-      for (const inventoryFile of inventoryFiles) {
-        const inventory = parseInventory(
-          await readFile(inventoryFile, "utf-8"),
-        );
-        runtime.addInventory(inventory);
-      }
-    }
-
-    agentContextOptions = {
-      tools: [
-        await runtime.toolIndex({
-          limit: options.toolLimit,
-        }),
-      ],
-    };
-  }
-
-  await Runtime.run(runtime, async () => {
-    // Evaluate input in an agent context.
-    await AgentContext.spawn(agentContextOptions, async () => {
-      // Run script, if not evaluating non-interactive code.
-      if (scriptFile !== undefined && (code === undefined || interactive)) {
-        const scriptPath = resolvePath(process.cwd(), scriptFile);
-        await import(scriptPath);
-        return;
-      }
-
-      // Instantiate a REPL to evaluate code.
-      const repl = new Repl();
-
-      // Evaluate the builtin prelude.
-      await repl.evalPrelude();
-
-      // Check if a code argument was provided.
-      if (code !== undefined) {
-        // Evaluate the code argument.
-        const bindings = await repl.evalCode(code);
-        // Check if the result should be printed.
-        if (print) {
-          // Print the result variable.
-          repl.output.write(repl.formatValue(bindings._1) + "\n");
-        }
-      }
-
-      // Check if the REPL should be run.
-      if (interactive || (code === undefined && process.stdin.isTTY)) {
-        // Stream responses when running the REPL.
-        if (runtime !== null && runtime.generatorConfig.stream == undefined) {
-          runtime.generatorConfig.stream = true;
-        }
-
-        // Print the REPL banner.
-        repl.printBanner();
-
-        // Run the REPL session.
-        await repl.run();
-      }
-    });
-  });
-};
-
-const createNodeCommand = (name: string): Command => {
-  return new Command(name)
-    .description("Run toolcog programs with Node.js")
-    .option(`-c, --config [${configFileName}]`, "Load config from a file")
-    .option<string[]>(
-      "--plugin <pluginModule...>",
-      "Load the specified plugin",
-      (moduleName, moduleNames) => [...moduleNames, ...moduleName.split(",")],
-      [],
-    )
-    .option<string[]>(
-      "--toolkit <toolkitModule...>",
-      "Load the specified toolkit",
-      (moduleName, moduleNames) => [...moduleNames, ...moduleName.split(",")],
-      [],
-    )
-    .option<number>(
-      "--tool-limit <count>",
-      "Maximum number of tools to select",
-      (value: string) => parseInt(value),
-      10,
-    )
-    .option(`--inventory [**/${inventoryFileName}]`, "Inventory files to load")
-    .option("--generative-model <model>", "The generative model to use")
-    .option("--embedding-model <model>", "The embedding model to use")
-    .option("-e, --eval <code>", "Evaluate code")
-    .option("-p, --print [code]", "Evaluate code and print the result")
-    .option(
-      "-i, --interactive",
-      "Start the REPL even if stdin does not appear to be a terminal",
-    )
-    .argument("[script.ts]", "The script to execute")
-    .action(runNodeCommand);
 };
 
 export type { NodeCommandOptions };

--- a/packages/framework/repl/src/lib.ts
+++ b/packages/framework/repl/src/lib.ts
@@ -1,9 +1,13 @@
-export type { MarkdownTheme } from "./markdown.ts";
+export type { MarkdownTheme } from "./render-markdown.ts";
 export {
   markdownTheme,
+  markdownTextTheme,
   renderMarkdown,
   renderMarkdownInline,
-} from "./markdown.ts";
+} from "./render-markdown.ts";
+
+export type { YamlishTheme } from "./render-yamlish.ts";
+export { yamlishTheme, renderYamlish } from "./render-yamlish.ts";
 
 export type {
   ReplImport,

--- a/packages/framework/repl/src/render-markdown.ts
+++ b/packages/framework/repl/src/render-markdown.ts
@@ -83,6 +83,21 @@ const markdownTheme: MarkdownTheme = {
   text: (text: string) => text,
 };
 
+const markdownTextTheme: MarkdownTheme = {
+  ...markdownTheme,
+  h1: (text: string) => style.magentaBright(style.bold(style.underline(text))),
+  h2: (text: string) => style.magenta(style.bold(style.underline(text))),
+  h3: (text: string) => style.magenta(style.bold(text)),
+  h4: (text: string) => style.gray(style.bold(text)),
+  h5: (text: string) => style.dim(style.bold(text)),
+  h6: (text: string) => style.dim(style.bold(style.italic(text))),
+  strong: (text: string) => style.bold(text),
+  em: (text: string) => style.italic(text),
+  codespan: (text: string) => style.yellow(text),
+  del: (text: string) => style.red(style.strikethrough(text)),
+  url: (url: string) => link(style.blue(style.underline(url)), url),
+};
+
 const renderMarkdown = (
   tokens: Token[] & { links?: Links },
   theme: MarkdownTheme = markdownTheme,
@@ -91,6 +106,7 @@ const renderMarkdown = (
   top: boolean = true,
 ): string => {
   let output = "";
+
   for (let i = 0; i < tokens.length; i += 1) {
     const token = tokens[i] as MarkedToken;
     if (token.type === "space") {
@@ -354,6 +370,7 @@ const renderMarkdownInline = (
   theme: MarkdownTheme,
 ): string => {
   let output = "";
+
   for (const token of tokens as MarkedToken[]) {
     if (token.type === "escape") {
       output += token.text;
@@ -395,6 +412,7 @@ const renderMarkdownInline = (
       throw new Error("Unexpected token " + JSON.stringify(token.type));
     }
   }
+
   return output;
 };
 
@@ -412,4 +430,9 @@ const unescape = (text: string): string => {
 };
 
 export type { MarkdownTheme };
-export { markdownTheme, renderMarkdown, renderMarkdownInline };
+export {
+  markdownTheme,
+  markdownTextTheme,
+  renderMarkdown,
+  renderMarkdownInline,
+};

--- a/packages/framework/repl/src/render-yamlish.ts
+++ b/packages/framework/repl/src/render-yamlish.ts
@@ -1,0 +1,183 @@
+import { EOL } from "node:os";
+import { replaceLines } from "@toolcog/util";
+import { getStringWidth, wrapText } from "@toolcog/util/tty";
+import { style } from "@toolcog/util/tui";
+
+interface YamlishTheme {
+  readonly bullet: string;
+  readonly heading: (text: string) => string;
+  readonly undefined: (text: string) => string;
+  readonly null: (text: string) => string;
+  readonly boolean: (text: string) => string;
+  readonly number: (text: string) => string;
+  readonly identifier: (text: string) => string;
+  readonly string: (text: string) => string;
+  readonly key: (text: string) => string;
+  readonly point: (text: string) => string;
+  readonly unknown: (text: string) => string;
+}
+
+const yamlishTheme: YamlishTheme = {
+  bullet: "-",
+  heading: (text: string) => style.cyan("[" + text + "]"),
+  undefined: style.gray,
+  null: style.bold,
+  boolean: style.yellow,
+  number: style.yellow,
+  identifier: (text: string) => text,
+  string: style.green,
+  key: style.gray,
+  point: (text: string) => style.dim(style.bold(text)),
+  unknown: style.blueBright,
+};
+
+const renderYamlish = (
+  heading: string | undefined,
+  value: unknown,
+  theme: YamlishTheme = yamlishTheme,
+  width: number = Infinity,
+  depth: number = 0,
+): string => {
+  let output = "";
+
+  if (heading !== undefined) {
+    output += " ".repeat(depth);
+    output += theme.heading(heading);
+    output += EOL;
+  }
+
+  output += renderYamlishValue(value, theme, width, depth);
+
+  return output;
+};
+
+const renderYamlishValue = (
+  value: unknown,
+  theme: YamlishTheme,
+  width: number,
+  depth: number,
+  output?: string,
+  listItem: boolean = false,
+): string => {
+  const indent = " ".repeat(depth);
+
+  if (value === undefined) {
+    if (output === undefined) {
+      output = indent;
+    }
+    output += theme.undefined("undefined");
+  } else if (value === null) {
+    if (output === undefined) {
+      output = indent;
+    }
+    output += theme.null("null");
+  } else if (typeof value === "boolean") {
+    if (output === undefined) {
+      output = indent;
+    }
+    output += theme.boolean(value ? "true" : "false");
+  } else if (typeof value === "number") {
+    if (output === undefined) {
+      output = indent;
+    }
+    output += theme.number(String(value));
+  } else if (typeof value === "string") {
+    if (output === undefined) {
+      output = indent;
+    }
+    if (/^[^\s:\n]*$/.test(value)) {
+      output += theme.identifier(value);
+    } else {
+      const json = JSON.stringify(value);
+      if (getStringWidth(json) <= width - getStringWidth(output)) {
+        output += theme.string(json);
+      } else {
+        output += ">";
+        output += EOL;
+        output += replaceLines(
+          wrapText(value.replace(/\r?\n/g, "\n\n"), width - indent.length),
+          (line) => indent + theme.string(line),
+        );
+      }
+    }
+  } else if (Array.isArray(value)) {
+    if (value.length === 0) {
+      if (output === undefined) {
+        output = indent;
+      }
+      output += "[]";
+    } else {
+      if (output === undefined) {
+        output = "";
+      } else {
+        output += EOL;
+      }
+      for (let i = 0; i < value.length; i += 1) {
+        let line = indent;
+        line += theme.point(theme.bullet);
+        line += " ";
+        line = renderYamlishValue(
+          value[i],
+          theme,
+          width,
+          depth + 2,
+          line,
+          true,
+        );
+        if (i !== 0) {
+          output += EOL;
+        }
+        output += line;
+      }
+    }
+  } else if (typeof value === "object") {
+    const keys = Object.keys(value);
+    if (keys.length === 0) {
+      if (output === undefined) {
+        output = indent;
+      }
+      output += "{}";
+    } else {
+      if (output === undefined) {
+        output = "";
+      } else if (!listItem) {
+        output += EOL;
+      }
+      for (let i = 0; i < keys.length; i += 1) {
+        const key = keys[i]!;
+        let line: string = i == 0 && listItem ? output : indent;
+        if (/^[^\s:\n]*$/.test(key)) {
+          line += theme.key(key);
+        } else {
+          line += theme.key(JSON.stringify(key));
+        }
+        line += ": ";
+        line = renderYamlishValue(
+          (value as Record<string, unknown>)[key],
+          theme,
+          width,
+          depth + 2,
+          line,
+        );
+        if (i === 0 && listItem) {
+          output = line;
+        } else {
+          if (i !== 0) {
+            output += EOL;
+          }
+          output += line;
+        }
+      }
+    }
+  } else {
+    if (output === undefined) {
+      output = indent;
+    }
+    output += theme.unknown(String(value));
+  }
+
+  return output;
+};
+
+export type { YamlishTheme };
+export { yamlishTheme, renderYamlish };

--- a/packages/framework/runtime/src/lib.ts
+++ b/packages/framework/runtime/src/lib.ts
@@ -66,7 +66,12 @@ export { cosineDistance, indexer } from "./indexer.ts";
 export type { RuntimeConfigSource, RuntimeConfig } from "./runtime.ts";
 export { Runtime, embed, index, generate, resolveIdiom } from "./runtime.ts";
 
-export type { JobOutputType, JobInfo, JobEvents } from "./job.ts";
+export type {
+  JobAttributes,
+  JobOutputType,
+  JobInfo,
+  JobEvents,
+} from "./job.ts";
 export { Job } from "./job.ts";
 
 export type { Precache } from "./precache.ts";


### PR DESCRIPTION
The `--print-markdown` options preserves markdown formatting in LLM responses. Without this option, LLM responses will be ANSI stylized with their markdown syntax removed, making them more readable. With this option, LLM responses will be ANSI stylized, while retaining their markdown syntax.

The `--print-tools` options prints the list of tools provided to the LLM for each generation call.

The `--print-tool-args` prints the arguments the LLM provides when calling a tool.

The `--print-tool-results` prints the return value of an LLN tool call. Tool results are now omitted from the output by default, as they can be quite verbose.