### PR TITLE
feat: Generate tuple schemas.

### DIFF
--- a/.changeset/six-phones-thank.md
+++ b/.changeset/six-phones-thank.md
@@ -1,0 +1,15 @@
+---
+"@toolcog/compiler": minor
+"@toolcog/util": minor
+---
+
+Generate tuple schemas.
+
+Update JSON schema types to use newer `prefixItems` and `items` properties.
+
+Fix schema generation for readonly arrays.
+
+Exclude un-representable schema elements:
+- Exclude properties with symbolic names from object schemas.
+- Exclude function properties from object schemas.
+- Exclude function variants from union types.

--- a/packages/framework/util/src/json/schema.ts
+++ b/packages/framework/util/src/json/schema.ts
@@ -56,8 +56,8 @@ interface Schema {
   readonly pattern?: string | undefined;
 
   // https://tools.ietf.org/html/draft-bhutton-json-schema-validation-01#section-6.4
-  readonly items?: readonly SchemaDefinition[] | SchemaDefinition | undefined;
-  readonly additionalItems?: SchemaDefinition | undefined;
+  readonly prefixItems?: readonly SchemaDefinition[] | undefined;
+  readonly items?: SchemaDefinition | undefined;
   readonly maxItems?: number | undefined;
   readonly minItems?: number | undefined;
   readonly uniqueItems?: boolean | undefined;

--- a/packages/framework/util/src/json/subtype.test.ts
+++ b/packages/framework/util/src/json/subtype.test.ts
@@ -302,30 +302,30 @@ describe("array constraint subtyping", () => {
     expect(isSubtype(subschema, superSchema)).toBe(false);
   });
 
-  it("should return true when subschema additionalItems is false and superSchema additionalItems is true", () => {
+  it("should return true when subschema items is false and superSchema items is true", () => {
     const subschema = {
       type: "array",
-      items: [{ type: "string" }],
-      additionalItems: false,
+      prefixItems: [{ type: "string" }],
+      items: false,
     } as const satisfies Schema;
     const superSchema = {
       type: "array",
-      items: [{ type: "string" }],
-      additionalItems: true,
+      prefixItems: [{ type: "string" }],
+      items: true,
     } as const satisfies Schema;
     expect(isSubtype(subschema, superSchema)).toBe(true);
   });
 
-  it("should return false when subschema additionalItems is true and superSchema additionalItems is false", () => {
+  it("should return false when subschema items is true and superSchema items is false", () => {
     const subschema = {
       type: "array",
-      items: [{ type: "string" }],
-      additionalItems: true,
+      prefixItems: [{ type: "string" }],
+      items: true,
     } as const satisfies Schema;
     const superSchema = {
       type: "array",
-      items: [{ type: "string" }],
-      additionalItems: false,
+      prefixItems: [{ type: "string" }],
+      items: false,
     } as const satisfies Schema;
     expect(isSubtype(subschema, superSchema)).toBe(false);
   });

--- a/packages/framework/util/src/json/subtype.ts
+++ b/packages/framework/util/src/json/subtype.ts
@@ -301,73 +301,51 @@ const compareArrayConstraints = (
   subschema: Schema,
   superSchema: Schema,
 ): boolean => {
-  if (subschema.items !== undefined) {
-    if (superSchema.items === undefined) {
+  if (subschema.prefixItems !== undefined) {
+    if (superSchema.prefixItems === undefined) {
       // `subschema` is more restrictive.
     } else {
-      if (Array.isArray(subschema.items) && Array.isArray(superSchema.items)) {
-        if (subschema.items.length !== superSchema.items.length) {
-          return false;
-        }
-        for (let i = 0; i < subschema.items.length; i += 1) {
-          if (
-            !isSubtype(
-              (subschema.items as readonly SchemaDefinition[])[i]!,
-              (superSchema.items as readonly SchemaDefinition[])[i]!,
-            )
-          ) {
-            return false;
-          }
-        }
-      } else if (
-        !Array.isArray(subschema.items) &&
-        !Array.isArray(superSchema.items)
-      ) {
+      if (subschema.prefixItems.length !== superSchema.prefixItems.length) {
+        return false;
+      }
+      for (let i = 0; i < subschema.prefixItems.length; i += 1) {
         if (
-          !isSubtype(
-            subschema.items as SchemaDefinition,
-            superSchema.items as SchemaDefinition,
-          )
+          !isSubtype(subschema.prefixItems[i]!, superSchema.prefixItems[i]!)
         ) {
           return false;
         }
-      } else {
-        // Incompatible items definitions.
-        return false;
       }
     }
   }
 
-  if (subschema.additionalItems !== undefined) {
-    if (superSchema.additionalItems === undefined) {
+  if (subschema.items !== undefined) {
+    if (superSchema.items === undefined) {
       // `superSchema` allows any additional items;
       // `subschema` may be more restrictive.
-    } else if (superSchema.additionalItems === false) {
-      if (subschema.additionalItems !== false) {
+    } else if (superSchema.items === false) {
+      if (subschema.items !== false) {
         // `subschema` allows any additional items, but `superSchema` does not.
         return false;
       }
-    } else if (typeof superSchema.additionalItems === "object") {
-      if (subschema.additionalItems === false) {
+    } else if (typeof superSchema.items === "object") {
+      if (subschema.items === false) {
         // `subschema` is more restrictive.
-      } else if (typeof subschema.additionalItems === "object") {
-        if (
-          !isSubtype(subschema.additionalItems, superSchema.additionalItems)
-        ) {
+      } else if (typeof subschema.items === "object") {
+        if (!isSubtype(subschema.items, superSchema.items)) {
           return false;
         }
       } else {
-        // `subschema.additionalItems` is `true` (allows any additional items);
-        // `superSchema.additionalItems` is an object (restricts additional items).
+        // `subschema.items` is `true` (allows any additional items);
+        // `superSchema.items` is an object (restricts additional items).
         return false;
       }
     }
-  } else if (superSchema.additionalItems !== undefined) {
-    if (superSchema.additionalItems === false) {
+  } else if (superSchema.items !== undefined) {
+    if (superSchema.items === false) {
       // `subschema` allows any additional items;
       // `superSchema` does not allow additional items.
       return false;
-    } else if (typeof superSchema.additionalItems === "object") {
+    } else if (typeof superSchema.items === "object") {
       // `subschema` allows any additional items, but `superSchema` restricts them.
       return false;
     }

--- a/packages/framework/util/src/json/validate.test.ts
+++ b/packages/framework/util/src/json/validate.test.ts
@@ -163,8 +163,8 @@ describe("array validation", () => {
   it("should validate tuple items constraints", () => {
     const schema = {
       type: "array",
-      items: [{ type: "number" }, { type: "string" }],
-      additionalItems: false,
+      prefixItems: [{ type: "number" }, { type: "string" }],
+      items: false,
     } as const satisfies Schema;
     expect(validate([1, "two"], schema)).toBe(true);
     expect(validate([1, "two", 3], schema)).toBe(false);


### PR DESCRIPTION
Update JSON schema types to use newer `prefixItems` and `items` properties.

Fix schema generation for readonly arrays.

Exclude un-representable schema elements:
- Exclude properties with symbolic names from object schemas.
- Exclude function properties from object schemas.
- Exclude function variants from union types.