### PR TITLE
feat: Support more flexible toolkit module definitions.

### DIFF
--- a/.changeset/sharp-pumpkins-kick.md
+++ b/.changeset/sharp-pumpkins-kick.md
@@ -1,0 +1,14 @@
+---
+"@toolcog/compiler": minor
+"@toolcog/runtime": minor
+"@toolcog/node": minor
+"@toolcog/repl": minor
+---
+
+Support more flexible toolkit module definitions.
+
+Default exports from toolkit modules can now be object literals, in addition
+to functions. Toolkit functions can now return an immediate object, in addition
+to a promise. And a toolkit's `tools` property can now be an immediate array of
+tools, a function that returns an array of tools, or a function that returns a
+promised array of tools.

--- a/packages/compiler/src/comment.ts
+++ b/packages/compiler/src/comment.ts
@@ -256,11 +256,7 @@ const getComment = (
   node: ts.Node,
   type?: ts.Type,
 ): Comment | undefined => {
-  if (type === undefined) {
-    type = checker?.getTypeAtLocation(node);
-  }
-  const symbol = checker?.getSymbolAtLocation(node);
-  const declaration = symbol?.declarations?.[0];
+  const declaration = checker?.getSymbolAtLocation(node)?.declarations?.[0];
   return mergeComments(
     type !== undefined ? getCommentForType(ts, type) : undefined,
     declaration !== undefined ? getCommentForNode(ts, declaration) : undefined,

--- a/packages/compiler/src/intrinsics/define-idioms.ts
+++ b/packages/compiler/src/intrinsics/define-idioms.ts
@@ -1,6 +1,7 @@
 import type ts from "typescript";
 import type { ModuleDef } from "@toolcog/runtime";
 import { error } from "../utils/errors.ts";
+import { moveLeadingComments } from "../utils/comments.ts";
 import { Diagnostics } from "../diagnostics.ts";
 import { defineIdiomExpression } from "./define-idiom.ts";
 
@@ -116,7 +117,15 @@ const defineIdiomsExpression = (
       ),
     );
   }
-  return factory.createArrayLiteralExpression(idiomExpressions, true);
+
+  const arrayExpression = factory.createArrayLiteralExpression(
+    idiomExpressions,
+    true,
+  );
+
+  moveLeadingComments(ts, valuesExpression, arrayExpression);
+
+  return ts.setOriginalNode(arrayExpression, valuesExpression);
 };
 
 export { defineIdiomsExpression };

--- a/packages/compiler/src/intrinsics/define-index.ts
+++ b/packages/compiler/src/intrinsics/define-index.ts
@@ -1,5 +1,6 @@
 import type ts from "typescript";
 import type { ModuleDef } from "@toolcog/runtime";
+import { moveLeadingComments } from "../utils/comments.ts";
 import { getNodeId } from "../node-id.ts";
 import { defineIdiomsExpression } from "./define-idioms.ts";
 
@@ -341,6 +342,8 @@ const defineIndexExpression = (
       indexerExpression,
     ],
   );
+
+  moveLeadingComments(ts, callExpression, iifeExpression);
 
   return ts.setOriginalNode(iifeExpression, callExpression);
 };

--- a/packages/compiler/src/intrinsics/define-prompt.ts
+++ b/packages/compiler/src/intrinsics/define-prompt.ts
@@ -1,6 +1,7 @@
 import type ts from "typescript";
 import type { ModuleDef } from "@toolcog/runtime";
 import { error } from "../utils/errors.ts";
+import { moveLeadingComments } from "../utils/comments.ts";
 import { valueToExpression } from "../utils/literals.ts";
 import { Diagnostics } from "../diagnostics.ts";
 import { getComment } from "../comment.ts";
@@ -666,6 +667,8 @@ const definePromptExpression = (
       ...(contextToolsExpression !== undefined ? [contextToolsExpression] : []),
     ],
   );
+
+  moveLeadingComments(ts, callExpression, iifeExpression);
 
   return ts.setOriginalNode(iifeExpression, callExpression);
 };

--- a/packages/compiler/src/intrinsics/define-tools.ts
+++ b/packages/compiler/src/intrinsics/define-tools.ts
@@ -1,6 +1,7 @@
 import type ts from "typescript";
 import type { ModuleDef } from "@toolcog/runtime";
 import { error } from "../utils/errors.ts";
+import { moveLeadingComments } from "../utils/comments.ts";
 import { Diagnostics } from "../diagnostics.ts";
 import { defineToolExpression } from "./define-tool.ts";
 
@@ -113,7 +114,15 @@ const defineToolsExpression = (
       ),
     );
   }
-  return factory.createArrayLiteralExpression(toolExpressions, true);
+
+  const arrayExpression = factory.createArrayLiteralExpression(
+    toolExpressions,
+    true,
+  );
+
+  moveLeadingComments(ts, funcsExpression, arrayExpression);
+
+  return ts.setOriginalNode(arrayExpression, funcsExpression);
 };
 
 export { defineToolsExpression };

--- a/packages/compiler/src/intrinsics/prompt.ts
+++ b/packages/compiler/src/intrinsics/prompt.ts
@@ -1,6 +1,7 @@
 import type ts from "typescript";
 import type { ModuleDef } from "@toolcog/runtime";
 import { error } from "../utils/errors.ts";
+import { moveLeadingComments } from "../utils/comments.ts";
 import { valueToExpression } from "../utils/literals.ts";
 import { Diagnostics } from "../diagnostics.ts";
 import { getComment } from "../comment.ts";
@@ -168,6 +169,8 @@ const promptExpression = (
       factory.createObjectLiteralExpression(optionsAssignments, true),
     ],
   );
+
+  moveLeadingComments(ts, callExpression, generatorCallExpression);
 
   return ts.setOriginalNode(generatorCallExpression, callExpression);
 };

--- a/packages/compiler/src/lib.ts
+++ b/packages/compiler/src/lib.ts
@@ -1,5 +1,7 @@
 /** @module . */
 
+export { moveLeadingComments } from "./utils/comments.ts";
+
 export { typeToSchema, signatureToSchema, callSiteToSchema } from "./schema.ts";
 
 export {

--- a/packages/compiler/src/schema.ts
+++ b/packages/compiler/src/schema.ts
@@ -633,7 +633,7 @@ const callSiteToSchema = (
     ...(parametersSchema !== undefined ?
       { parameters: parametersSchema }
     : undefined),
-    ...(returnSchema !== undefined ? { return: returnSchema } : undefined),
+    ...(returnSchema !== undefined ? { returns: returnSchema } : undefined),
   };
 };
 

--- a/packages/compiler/src/utils/comments.ts
+++ b/packages/compiler/src/utils/comments.ts
@@ -195,6 +195,7 @@ const copyLeadingComments = <T extends ts.Node>(
   return toNode;
 };
 
+/** @internal */
 const moveLeadingComments = <T extends ts.Node>(
   ts: typeof import("typescript"),
   fromNode: ts.Node,
@@ -202,12 +203,13 @@ const moveLeadingComments = <T extends ts.Node>(
 ): T => {
   copyLeadingComments(ts, fromNode, toNode);
 
-  ts.setSyntheticLeadingComments(fromNode, undefined);
-
-  ts.setEmitFlags(
-    fromNode,
-    ts.EmitFlags.NoLeadingComments | ts.EmitFlags.NoTrailingComments,
-  );
+  if (fromNode.getSourceFile() !== undefined) {
+    ts.setSyntheticLeadingComments(fromNode, undefined);
+    ts.setEmitFlags(
+      fromNode,
+      ts.EmitFlags.NoLeadingComments | ts.EmitFlags.NoTrailingComments,
+    );
+  }
 
   return toNode;
 };

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -248,15 +248,14 @@ const loadToolkits = async (
 
   const toolkitSources: ToolkitSource[] = [];
   for (const [moduleName, moduleImport] of Object.entries(toolkitModules)) {
-    const module = moduleImport as { readonly default?: () => Toolkit };
-    if (module.default === undefined) {
+    const toolkitModule = moduleImport as { readonly default?: () => Toolkit };
+    if (toolkitModule.default === undefined) {
       throw new Error(
         "Toolkit " + JSON.stringify(moduleName) + " has no default export",
-        { cause: module },
+        { cause: toolkitModule },
       );
     }
-    const toolkitSource = module.default();
-    toolkitSources.push(toolkitSource);
+    toolkitSources.push(toolkitModule);
   }
   const toolkits = await resolveToolkits(toolkitSources);
 

--- a/packages/runtime/src/lib.ts
+++ b/packages/runtime/src/lib.ts
@@ -45,8 +45,17 @@ export {
 export type { Plugin, PluginModule, PluginSource } from "./plugin.ts";
 export { resolvePlugin, resolvePlugins } from "./plugin.ts";
 
-export type { Toolkit, ToolkitModule, ToolkitSource } from "./toolkit.ts";
-export { resolveToolkit, resolveToolkits } from "./toolkit.ts";
+export type {
+  ToolkitTools,
+  Toolkit,
+  ToolkitModule,
+  ToolkitSource,
+} from "./toolkit.ts";
+export {
+  resolveToolkitTools,
+  resolveToolkit,
+  resolveToolkits,
+} from "./toolkit.ts";
 
 export type {
   AgentConfig,

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -20,7 +20,7 @@ import { indexer } from "./indexer.ts";
 import type { Plugin, PluginSource } from "./plugin.ts";
 import { resolvePlugins } from "./plugin.ts";
 import type { Toolkit, ToolkitSource } from "./toolkit.ts";
-import { resolveToolkits } from "./toolkit.ts";
+import { resolveToolkitTools, resolveToolkits } from "./toolkit.ts";
 import type { Inventory, InventorySource } from "./inventory.ts";
 import { createInventory, resolveInventory } from "./inventory.ts";
 
@@ -379,7 +379,9 @@ class Runtime {
    */
   async toolIndex(options?: IndexerOptions): Promise<Index<readonly Tool[]>> {
     const tools = (
-      await Promise.all(this.toolkits.map((toolkit) => toolkit.tools?.() ?? []))
+      await Promise.all(
+        this.toolkits.map((toolkit) => resolveToolkitTools(toolkit.tools)),
+      )
     ).flat();
     return await this.index(tools, options);
   }

--- a/packages/runtime/src/toolkit.ts
+++ b/packages/runtime/src/toolkit.ts
@@ -1,6 +1,29 @@
 import type { Tool } from "@toolcog/core";
 
 /**
+ * The set of LLM tools provided by a toolkit.
+ */
+type ToolkitTools =
+  | (() => Promise<readonly Tool[]> | readonly Tool[] | undefined)
+  | readonly Tool[]
+  | undefined;
+
+/**
+ * Resolves the LLM tools provided by a toolkit into an array of `Tool`s
+ *
+ * @param tools - The set of LLM tools provided by a toolkit.
+ * @returns The LLM tools resolved from the toolkit.
+ */
+const resolveToolkitTools = async (
+  tools: ToolkitTools,
+): Promise<readonly Tool[]> => {
+  if (typeof tools === "function") {
+    tools = await tools();
+  }
+  return tools ?? [];
+};
+
+/**
  * A package of LLM tools related to a particular API or service.
  *
  * Toolkits typically contain more tools than would be used in a single task.
@@ -21,7 +44,7 @@ interface Toolkit {
   /**
    * The LLM tools provided by the toolkit.
    */
-  readonly tools?: () => Promise<readonly Tool[]>;
+  readonly tools?: ToolkitTools;
 }
 
 /**
@@ -101,5 +124,5 @@ const resolveToolkits: {
   }, []);
 }) as typeof resolveToolkits;
 
-export type { Toolkit, ToolkitModule, ToolkitSource };
-export { resolveToolkit, resolveToolkits };
+export type { ToolkitTools, Toolkit, ToolkitModule, ToolkitSource };
+export { resolveToolkitTools, resolveToolkit, resolveToolkits };


### PR DESCRIPTION
Default exports from toolkit modules can now be object literals, in addition to functions. Toolkit functions can now return an immediate object, in addition to a promise. And a toolkit's `tools` property can now be an immediate array of tools, a function that returns an array of tools, or a function that returns a promised array of tools.

Fixed an issue that caused comments to be inadvertently analyzed for the return types of `defineTool` calls.

Fixed `callSiteToSchema` using an incorrectly spelled `return` property.

All intrinsic transformers now consistently preserve comments that were attached to the original intrinsic call expression.